### PR TITLE
Iat 47

### DIFF
--- a/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
@@ -105,8 +105,8 @@ public class GitClient {
 
     public void createScratchPad() {
         try {
-            git.branchCreate().setName(SCRATCH_PAD).call();
-            git.checkout().setName(SCRATCH_PAD).call();
+            git.branchCreate().setName(userInfo.getUsername()).call();
+            git.checkout().setName(userInfo.getUsername()).call();
         } catch (GitAPIException e) {
             throw new SystemException("Problem creating scratch pad branch", e);
         }

--- a/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
@@ -166,19 +166,6 @@ public class GitClient {
     }
 
     /**
-     * Writes a README.md file to the local repository.  The README file is empty.
-     */
-    public void writeEmptyReadMe() {
-        final String readmeFilePath = generateLocalFilePath(README_FILE);
-        log.debug("generate readme {}", readmeFilePath);
-        try {
-            Files.createFile(Paths.get(readmeFilePath));
-        } catch (IOException e) {
-            throw new SystemException("Error generating readme for repository " + repository, e);
-        }
-    }
-
-    /**
      * Writes the item to the local repository in XML format.
      *
      * @param item The item to write to a file.

--- a/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
@@ -161,7 +161,7 @@ public class GitClient {
         try {
             add.addFilepattern(filePattern).call();
         } catch (GitAPIException e) {
-            throw new SystemException("Error adding README file", e);
+            throw new SystemException("Error staging files.", e);
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
@@ -28,7 +28,7 @@ import org.opentestsystem.ap.ims.entity.ItemBankUser;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
 import org.opentestsystem.saaif.item.ItemRelease;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.io.IOException;
  * Item bank GitLab repository implementation.
  */
 @Slf4j
-@Repository
+@Component
 public class ItemBankRepository {
 
     private final ItemBankProperties itemBankProperties;
@@ -87,7 +87,6 @@ public class ItemBankRepository {
         createProject(group, itemId);
 
         final GitClient cli = gitClientFactory.cloneRemoteRepository(user, itemId);
-        cli.writeEmptyReadMe();
         cli.commit(itemBankProperties.getInitialCommitMessage());
         cli.push();
 

--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
@@ -26,6 +26,7 @@ import org.opentestsystem.ap.ims.client.GitClientFactory;
 import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.entity.ItemBankUser;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
+import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemRelease;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -142,7 +143,7 @@ public class ItemBankRepository {
                 (String) null               // importUrl
             );
         } catch (IOException e) {
-            throw new RuntimeException("Error creating project", e);
+            throw new SystemException("Error creating project", e);
         }
         return project;
     }
@@ -158,7 +159,7 @@ public class ItemBankRepository {
         try {
             return gitlabApi.getGroup(itemBankProperties.getGroup());
         } catch (IOException e) {
-            throw new RuntimeException("Error looking up Gitlab Group", e);
+            throw new SystemException("Error looking up Gitlab Group", e);
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
@@ -133,10 +133,10 @@ public class ItemBankRepository {
                 (Integer) group.getId(),    // namespaceId
                 (String) null,              // description
                 Boolean.TRUE,               // issuesEnabled
-                Boolean.TRUE,               // wallEnabled
-                Boolean.TRUE,               // mergeRequestsEnabled
-                Boolean.TRUE,               // wikiEnabled
-                Boolean.TRUE,               // snippetsEnabled
+                Boolean.FALSE,               // wallEnabled
+                Boolean.FALSE,               // mergeRequestsEnabled
+                Boolean.FALSE,               // wikiEnabled
+                Boolean.FALSE,               // snippetsEnabled
                 Boolean.FALSE,              // publik
                 0,                          // visibilityLevel
                 (String) null               // importUrl

--- a/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
+++ b/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
@@ -62,7 +62,7 @@ public class ItemApi {
      *
      * @return The item's unique identifier.
      */
-    @PutMapping
+    @PutMapping("/{itemId}")
     public void updateItem(@PathVariable String itemId, @RequestBody Item request) {
         itemBankService.updateItem(itemId, request);
     }

--- a/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
+++ b/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
@@ -26,10 +26,10 @@ import org.opentestsystem.ap.ims.util.ValidationException;
 import org.opentestsystem.saaif.item.ItemFactory;
 import org.opentestsystem.saaif.item.ItemRelease;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
 public class ItemBankService {
 
     private final ItemBankRepository itemBankRepository;

--- a/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
+++ b/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
@@ -58,7 +58,7 @@ public class ItemBankService {
         }
         final ItemBankUser user = securityUtil.getItemBankUser();
         final String itemId = itemBankRepository.initializeNewItem(user);
-        final ItemRelease itemWrapper = itemFactory.newMinimumItemWrapper(itemId, itemRequest.getType());
+        final ItemRelease itemWrapper = itemFactory.newAssessmentItem(itemId, itemRequest.getType());
         itemBankRepository.initializeItemType(user, itemWrapper);
         return itemId;
     }

--- a/src/main/java/org/opentestsystem/ap/ims/util/ItemIdGenerator.java
+++ b/src/main/java/org/opentestsystem/ap/ims/util/ItemIdGenerator.java
@@ -15,11 +15,13 @@
  */
 package org.opentestsystem.ap.ims.util;
 
+import lombok.Getter;
 import org.apache.commons.lang3.RandomUtils;
 
 /**
  * Randomly generates an ID between the given min (inclusive) and max (exclusive) values.
  */
+@Getter
 public class ItemIdGenerator {
 
     private final int minValue;

--- a/src/main/java/org/opentestsystem/saaif/item/ItemFactory.java
+++ b/src/main/java/org/opentestsystem/saaif/item/ItemFactory.java
@@ -22,7 +22,6 @@ import static org.opentestsystem.saaif.item.ItemConstants.ItemAttribute.ItemId;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemAttribute.ItemPageLayout;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemAttribute.ItemResponseType;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
-import static org.opentestsystem.saaif.item.ItemConstants.ItemLanguage.LANG_ENU;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemPageLayout.PAGE_LAYOUT_SHORT_ANSWER;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemResponseType.RESPONSE_TYPE_HTML_EDITOR;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemVersion.ITEM_RELEASE_VERSION;
@@ -37,21 +36,6 @@ public class ItemFactory {
     private static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
 
     /**
-     * The minimum valid {@link org.opentestsystem.saaif.item.ItemRelease} instance using
-     * ENU as the only language to create a content section for.
-     *
-     * @param itemId     The item id to set.
-     * @param itemFormat The item format to create.
-     * @return An {@link org.opentestsystem.saaif.item.ItemRelease} instance.
-     */
-    public ItemRelease newMinimumItemWrapper(String itemId, String itemFormat) {
-        final ItemRelease itemRelease = OBJECT_FACTORY.createItemrelease();
-        itemRelease.setVersion(ITEM_RELEASE_VERSION);
-        itemRelease.setItem(newItem(itemId, itemFormat));
-        return newItemWrapper(itemId, itemFormat, LANG_ENU);
-    }
-
-    /**
      * The minimum valid {@link org.opentestsystem.saaif.item.ItemRelease} instance.
      *
      * @param itemId     The item id to set.
@@ -59,7 +43,7 @@ public class ItemFactory {
      * @param languages  The content sections to create, one per language.
      * @return An {@link org.opentestsystem.saaif.item.ItemRelease} instance.
      */
-    public ItemRelease newItemWrapper(String itemId, String itemFormat, String... languages) {
+    public ItemRelease newAssessmentItem(String itemId, String itemFormat, String... languages) {
         final ItemRelease itemRelease = OBJECT_FACTORY.createItemrelease();
         itemRelease.setVersion(ITEM_RELEASE_VERSION);
         itemRelease.setItem(newItem(itemId, itemFormat, languages));
@@ -178,62 +162,5 @@ public class ItemFactory {
         attribute.setVal(val);
         attribute.setDesc(EMPTY);
         return attribute;
-    }
-
-    public ItemRelease.Item.Content.Rubriclist.Rubric newRubric(Integer index, String scorepoint, String name,
-                                                                String val) {
-        final ItemRelease.Item.Content.Rubriclist.Rubric rubric = OBJECT_FACTORY
-            .createItemreleaseItemContentRubriclistRubric();
-        rubric.setIndex(index);
-        rubric.setScorepoint(scorepoint);
-        rubric.setName(name);
-        rubric.setVal(val);
-        return rubric;
-    }
-
-    public ItemRelease.Item.Content.Rubriclist.Samplelist newSamplelist(Integer index, String minScore,
-                                                                        String maxScore) {
-        final ItemRelease.Item.Content.Rubriclist.Samplelist samples = OBJECT_FACTORY
-            .createItemreleaseItemContentRubriclistSamplelist();
-        samples.setIndex(index);
-        samples.setMinval(b(minScore));
-        samples.setMaxval(b(maxScore));
-        return samples;
-    }
-
-    public ItemRelease.Item.Content.Rubriclist.Samplelist.Sample newSample(String purpose, String scorepoint,
-                                                                           String name, String sampleContent) {
-        final ItemRelease.Item.Content.Rubriclist.Samplelist.Sample sample = OBJECT_FACTORY
-            .createItemreleaseItemContentRubriclistSamplelistSample();
-        sample.setPurpose(purpose);
-        sample.setScorepoint(b(scorepoint));
-        sample.setName(name);
-        sample.setSamplecontent(sampleContent);
-        return sample;
-    }
-
-    // ------------------------------------------------------------------------
-
-    /**
-     * Converts int to Byte
-     *
-     * @param val The int value
-     * @return The int converted to a Byte.
-     */
-    private Byte b(int val) {
-        return (byte) val;
-    }
-
-    /**
-     * Converts String to Byte.
-     *
-     * @param val The String value.
-     * @return The String converted to a Byte.
-     */
-    private Byte b(String val) {
-        if (val == null || val.length() == 0) {
-            return null;
-        }
-        return Byte.valueOf(val);
     }
 }

--- a/src/main/java/org/opentestsystem/saaif/item/ItemFactory.java
+++ b/src/main/java/org/opentestsystem/saaif/item/ItemFactory.java
@@ -180,8 +180,8 @@ public class ItemFactory {
         return attribute;
     }
 
-    public ItemRelease.Item.Content.Rubriclist.Rubric newRubric(Integer index, String scorepoint, String name, String
-        val) {
+    public ItemRelease.Item.Content.Rubriclist.Rubric newRubric(Integer index, String scorepoint, String name,
+                                                                String val) {
         final ItemRelease.Item.Content.Rubriclist.Rubric rubric = OBJECT_FACTORY
             .createItemreleaseItemContentRubriclistRubric();
         rubric.setIndex(index);
@@ -191,8 +191,8 @@ public class ItemFactory {
         return rubric;
     }
 
-    public ItemRelease.Item.Content.Rubriclist.Samplelist newSamplelist(Integer index, String minScore, String
-        maxScore) {
+    public ItemRelease.Item.Content.Rubriclist.Samplelist newSamplelist(Integer index, String minScore,
+                                                                        String maxScore) {
         final ItemRelease.Item.Content.Rubriclist.Samplelist samples = OBJECT_FACTORY
             .createItemreleaseItemContentRubriclistSamplelist();
         samples.setIndex(index);
@@ -228,7 +228,7 @@ public class ItemFactory {
      * Converts String to Byte.
      *
      * @param val The String value.
-     * @return The int converted to a Byte.
+     * @return The String converted to a Byte.
      */
     private Byte b(String val) {
         if (val == null || val.length() == 0) {

--- a/src/test/java/org/opentestsystem/ap/ims/IMSApplicationSecurityConfigIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/IMSApplicationSecurityConfigIT.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@ActiveProfiles(value = "it-test, security-on")
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class IMSApplicationSecurityConfigIT {
+
+    @Test
+    public void itShouldConfigureSecurityOnAppStartup() {
+
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
@@ -207,13 +207,6 @@ public class GitClientTest {
     }
 
     @Test
-    public void itShouldWriteReadMeFileToLocalGitRepository() {
-        gitClient.writeEmptyReadMe();
-        assertThat(new File(itemBankTestUtil.getLocalRepoDir().toString() + "/" + README_FILE).isFile())
-            .isEqualTo(true);
-    }
-
-    @Test
     public void itShouldGenerateRepositoryURI() {
         final String expected = String.format("%s/%s/%s.git",
             itemBankTestUtil.getGitlabHost(),

--- a/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
@@ -113,7 +113,7 @@ public class GitClientTest {
 
     @Test
     public void itShouldReadItemFile() {
-        final ItemRelease expected = FACTORY.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease expected = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
         gitClient.writeItemFile(expected);
 
         final ItemRelease actual = spyGitClient.readItemFile();

--- a/src/test/java/org/opentestsystem/ap/ims/config/ItemBankConfigTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/ItemBankConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.ims.util.ItemIdGenerator;
+import org.opentestsystem.saaif.item.ItemFactory;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ItemBankConfigTest {
+
+    @Mock
+    private ItemBankProperties mockItemBankProperties;
+
+    private ItemBankConfig itemBankConfig;
+
+    @Before
+    public void setup() {
+        itemBankConfig = new ItemBankConfig(mockItemBankProperties);
+
+    }
+
+    @Test
+    public void itShouldCreateGitlabSession() {
+        when(mockItemBankProperties.getHost()).thenReturn("https://localhost:8080");
+        when(mockItemBankProperties.getUser()).thenReturn("user");
+        when(mockItemBankProperties.getPassword()).thenReturn("password");
+
+        try {
+            itemBankConfig.gitlabSession();
+        } catch (IOException e) {
+            // expected, connection properties are not valid
+        }
+
+        verify(mockItemBankProperties, times(1)).getHost();
+        verify(mockItemBankProperties, times(1)).getUser();
+        verify(mockItemBankProperties, times(1)).getPassword();
+    }
+
+    @Test
+    public void itShouldCreateItemIdGenerator() {
+        when(mockItemBankProperties.getIdMinValue()).thenReturn(1);
+        when(mockItemBankProperties.getIdMaxValue()).thenReturn(10);
+
+        final ItemIdGenerator itemIdGenerator = itemBankConfig.itemIdGenerator();
+        assertThat(itemIdGenerator).isNotNull();
+        assertThat(itemIdGenerator.getMinValue()).isEqualTo(1);
+        assertThat(itemIdGenerator.getMaxValue()).isEqualTo(10);
+    }
+
+    @Test
+    public void itShouldCreateItemFactory() {
+        final ItemFactory itemFactory = itemBankConfig.itemFactory();
+        assertThat(itemFactory).isNotNull();
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/config/NoRedisSessionConfig.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/NoRedisSessionConfig.java
@@ -31,12 +31,12 @@ import java.io.IOException;
  */
 @Configuration
 @ConditionalOnProperty(value = "itembank.test.enabled", havingValue = "true", matchIfMissing = false)
-public class ItemBankTestConfig {
+public class NoRedisSessionConfig {
 
     public final ItemBankProperties props;
 
     @Autowired
-    public ItemBankTestConfig(ItemBankProperties props) {
+    public NoRedisSessionConfig(ItemBankProperties props) {
         this.props = props;
     }
 

--- a/src/test/java/org/opentestsystem/ap/ims/config/RedisSessionConfigTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/RedisSessionConfigTest.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.config;
+
+import org.junit.Test;
+
+public class RedisSessionConfigTest {
+
+    @Test
+    public void itShouldInstantiateTheConfigClass() {
+        new RedisSessionConfig();
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/entity/ErrorMessageTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/entity/ErrorMessageTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.entity;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorMessageTest {
+
+
+    @Test
+    public void itShouldCreateErrorMessage() {
+        final ErrorMessage msg = new ErrorMessage("message");
+        assertThat(msg.getMessage()).isEqualTo("message");
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/entity/ItemBankUserTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/entity/ItemBankUserTest.java
@@ -23,6 +23,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ItemBankUserTest {
 
     @Test
+    public void itShouldParseUserName() {
+        final ItemBankUser u1 = new ItemBankUser("test1", "Test User");
+        assertThat(u1.parseUsername()).isEqualTo("test1");
+
+        final ItemBankUser u2 = new ItemBankUser("test1@sbac.com", "Test User");
+        assertThat(u2.parseUsername()).isEqualTo("test1");
+    }
+
+    @Test
     public void twoItemBankUserInstancesShouldBeEqual() {
         final ItemBankUser u1 = new ItemBankUser("test", "Test User");
         final ItemBankUser u2 = new ItemBankUser("test", "Test User");

--- a/src/test/java/org/opentestsystem/ap/ims/entity/ItemTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/entity/ItemTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.entity;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ItemTest {
+
+    @Test
+    public void itShouldUseNoArgConstructor() {
+        new Item();
+    }
+
+    @Test
+    public void itShouldConfirmItemsAreEqual() {
+        final Item item1 = Item.builder().id("id").type("type").build();
+        final Item item2 = new Item("id", "type");
+        assertThat(item1).isEqualTo(item2);
+        assertItem(item1);
+        assertItem(item2);
+    }
+
+    private void assertItem(Item item) {
+        assertThat(item.getId()).isEqualTo("id");
+        assertThat(item.getType()).isEqualTo("type");
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
@@ -93,7 +93,7 @@ public class ItemBankRepositoryTest {
 
     @Test
     public void itShouldInitializeItemType() {
-        final ItemRelease item = ITEM_FACTORY.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease item = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
 
         when(mockGitClientFactory.openRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
 
@@ -117,7 +117,7 @@ public class ItemBankRepositoryTest {
 
 
         verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
-            Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, 0, null);
+            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
     }
 
     @SuppressWarnings("deprecation")
@@ -126,7 +126,7 @@ public class ItemBankRepositoryTest {
         repository.createProject(mockGroup, ITEM_ID);
 
         verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
-            Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, 0, null);
+            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
@@ -17,6 +17,7 @@ package org.opentestsystem.ap.ims.repository;
 
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.models.GitlabGroup;
+import org.gitlab.api.models.GitlabSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,8 +25,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.ims.client.GitClient;
 import org.opentestsystem.ap.ims.client.GitClientFactory;
+import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.util.ItemBankTestUtil;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
+import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemRelease;
 
 import java.io.IOException;
@@ -52,6 +55,9 @@ public class ItemBankRepositoryTest {
     private ItemIdGenerator mockItemIdGenerator;
 
     @Mock
+    private GitlabSession mockGitLabSession;
+
+    @Mock
     private GitlabAPI mockGitlabApi;
 
     @Mock
@@ -63,9 +69,13 @@ public class ItemBankRepositoryTest {
     @Mock
     private GitClientFactory mockGitClientFactory;
 
+    @Mock
+    private ItemBankProperties mockItemBankProperties;
+
     private ItemBankRepository repository;
 
     private ItemBankRepository spyRepository;
+
 
     @Before
     public void setup() throws IOException {
@@ -76,12 +86,30 @@ public class ItemBankRepositoryTest {
         when(mockGitClientFactory.openRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
 
         repository = new ItemBankRepository(
-            TEST_UTIL.getGitlabProperties(), null, mockItemIdGenerator, mockGitClientFactory);
+            TEST_UTIL.getGitlabProperties(), mockGitLabSession, mockItemIdGenerator, mockGitClientFactory);
 
         repository.setGitlabApi(mockGitlabApi);
 
         spyRepository = spy(repository);
         doReturn(mockGroup).when(spyRepository).getGroup();
+        doReturn(mockGroup).when(spyRepository).lookupGroup();
+    }
+
+    @Test
+    public void itShouldInitialize() {
+        repository.initialize();
+
+        when(mockItemBankProperties.getHost()).thenReturn("host");
+        when(mockGitLabSession.getPrivateToken()).thenReturn("token");
+        try {
+            repository.initialize();
+        } catch(Exception e) {
+        }
+    }
+
+    @Test
+    public void itShouldGetGroup() {
+        final GitlabGroup group = repository.getGroup();
     }
 
     @Test
@@ -118,6 +146,20 @@ public class ItemBankRepositoryTest {
 
         verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
             Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test(expected = SystemException.class)
+    public void itShouldThrowSystemExceptionWhenCreatingProject() throws IOException {
+        final IOException ioException = new IOException("IO exception");
+
+        when(mockGitlabApi.createProject(ITEM_ID, GROUP_ID, null,
+            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null))
+            .thenThrow(ioException);
+
+        repository.createProject(mockGroup, ITEM_ID);
+
+
     }
 
     @SuppressWarnings("deprecation")

--- a/src/test/java/org/opentestsystem/ap/ims/rest/ExceptionAdviceTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/rest/ExceptionAdviceTest.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.rest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.ap.ims.entity.ErrorMessage;
+import org.opentestsystem.ap.ims.util.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionAdviceTest {
+
+    private ExceptionAdvice exceptionAdvice;
+
+    @Before
+    public void setup() {
+        exceptionAdvice = new ExceptionAdvice();
+    }
+
+    @Test
+    public void itShouldHandleValidationException() {
+        final ValidationException validationException = new ValidationException("validation error");
+
+        final ResponseEntity<List<ErrorMessage>> responseEntity = exceptionAdvice.handleValidationException
+            (validationException);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(responseEntity.getBody()).hasSize(1);
+        assertThat(responseEntity.getBody().get(0).getMessage()).isEqualTo("validation error");
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
@@ -22,13 +22,26 @@ import org.opentestsystem.ap.ims.service.ItemBankService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.mock.http.MockHttpOutputMessage;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_ID;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -37,7 +50,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ItemApi.class)
 public class ItemApiIT {
 
-    private static final String NEW_ITEM_ID = "new-item-id";
+    private final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+        MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
     @Autowired
     private MockMvc mvc;
@@ -45,12 +59,47 @@ public class ItemApiIT {
     @MockBean
     private ItemBankService itemBankService;
 
+    private HttpMessageConverter mappingJackson2HttpMessageConverter;
+
+    @Autowired
+    void setConverters(HttpMessageConverter<?>[] converters) {
+
+        this.mappingJackson2HttpMessageConverter = Arrays.asList(converters).stream()
+            .filter(hmc -> hmc instanceof MappingJackson2HttpMessageConverter)
+            .findAny()
+            .orElse(null);
+
+        assertNotNull("the JSON message converter must not be null",
+            this.mappingJackson2HttpMessageConverter);
+    }
+
     @Test
     public void testCreateItem() throws Exception {
         final Item newItemRequest = Item.builder().type(FORMAT_SHORT_ANSWER).build();
-        given(itemBankService.createItem(newItemRequest)).willReturn(NEW_ITEM_ID);
-        mvc.perform(post("/api/v1/items/").contentType("application/json").content("{\"type\":\"" + FORMAT_SHORT_ANSWER + "\"}")
-            ).andExpect(status().isOk()).andExpect(content().string("{\"id\":\"new-item-id\",\"type\":\"sa\"}"));
+        given(itemBankService.createItem(newItemRequest)).willReturn(ITEM_ID);
+        mvc.perform(post("/api/v1/items/")
+            .contentType(contentType)
+            .content(this.json(newItemRequest)))
+            .andExpect(status().isOk())
+            .andExpect(content().string("{\"id\":\"" + ITEM_ID + "\",\"type\":\"sa\"}"));
+    }
+
+    @Test
+    public void testUpdateItem() throws Exception {
+        final Item itemToUpdate = Item.builder().type(FORMAT_SHORT_ANSWER).build();
+
+        mvc.perform(put("/api/v1/items/" + ITEM_ID)
+            .contentType(contentType)
+            .content(this.json(itemToUpdate)))
+            .andExpect(status().isOk());
+
+        verify(itemBankService, times(1)).updateItem(ITEM_ID, itemToUpdate);
+    }
+
+    protected String json(Object o) throws IOException {
+        MockHttpOutputMessage mockHttpOutputMessage = new MockHttpOutputMessage();
+        this.mappingJackson2HttpMessageConverter.write(o, MediaType.APPLICATION_JSON, mockHttpOutputMessage);
+        return mockHttpOutputMessage.getBodyAsString();
     }
 
 }

--- a/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.ims.entity.Item;
 import org.opentestsystem.ap.ims.repository.ItemBankRepository;
 import org.opentestsystem.ap.ims.util.SecurityUtil;
+import org.opentestsystem.ap.ims.util.ValidationException;
 import org.opentestsystem.saaif.item.ItemFactory;
 import org.opentestsystem.saaif.item.ItemRelease;
 
@@ -54,9 +55,19 @@ public class ItemBankServiceTest {
         when(securityUtil.getItemBankUser()).thenReturn(ITEM_BANK_USER);
         when(securityUtil.getUsername()).thenReturn(ITEM_BANK_USER.getUsername());
         when(securityUtil.getFullname()).thenReturn(ITEM_BANK_USER.getFullname());
-
-
         service = new ItemBankService(repository, itemFactory, securityUtil);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void createItemShouldThrowValidationExceptionWhenPassedNull() {
+        service.createItem(null);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void createItemShouldThrowValidationExceptionWhenPassedEmptyItemType() {
+        Item item = new Item();
+        item.setType(null);
+        service.createItem(item);
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
@@ -61,10 +61,10 @@ public class ItemBankServiceTest {
 
     @Test
     public void itShouldCreateItem() {
-        final ItemRelease item = ITEM_FACTORY.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease item = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
 
         when(repository.initializeNewItem(ITEM_BANK_USER)).thenReturn(ITEM_ID);
-        when(itemFactory.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER)).thenReturn(item);
+        when(itemFactory.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER)).thenReturn(item);
 
         final Item newItemRequest = Item.builder().type(FORMAT_SHORT_ANSWER).build();
         newItemRequest.setType(FORMAT_SHORT_ANSWER);
@@ -74,7 +74,7 @@ public class ItemBankServiceTest {
         assertThat(itemId).isEqualTo(ITEM_ID);
 
         verify(repository, times(1)).initializeNewItem(ITEM_BANK_USER);
-        verify(itemFactory, times(1)).newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        verify(itemFactory, times(1)).newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
         verify(repository, times(1)).initializeItemType(ITEM_BANK_USER, item);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/ims/util/ItemAssemblerTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/ItemAssemblerTest.java
@@ -61,7 +61,7 @@ public class ItemAssemblerTest {
 
     @Test
     public void itShouldMarshalObjectToXMLAndWriteItToFile() {
-        final ItemRelease shortAnswer = FACTORY.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
         itemAssembler.writeXmlToFile(shortAnswer, Paths.get(itemBankTestUtil.getLocalRepoDir().toString(), "item-file.xml"));
         assertThat(Files.exists(itemFilePath)).isEqualTo(true);
     }
@@ -69,7 +69,7 @@ public class ItemAssemblerTest {
     @Test
     public void itShouldUnmarshalXMLFileToObject() {
         final Path itemXmlFile = Paths.get(itemBankTestUtil.getLocalRepoDir().toString(), "item-file.xml");
-        final ItemRelease shortAnswer = FACTORY.newMinimumItemWrapper(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
         itemAssembler.writeXmlToFile(shortAnswer, itemXmlFile);
 
         final ItemRelease item = itemAssembler.readXmlFromFile(itemXmlFile);

--- a/src/test/java/org/opentestsystem/ap/ims/util/SecurityUtilTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/SecurityUtilTest.java
@@ -50,6 +50,13 @@ public class SecurityUtilTest {
     private SecurityUtil spy;
 
     @Test
+    public void itShouldGetItemBankUserNoArgs() {
+        final ItemBankUser user = spy.getItemBankUser();
+        assertThat(user.getUsername()).isEqualTo(USER_ANONYMOUS);
+        assertThat(user.getFullname()).isEqualTo(USER_ANONYMOUS);
+    }
+    
+    @Test
     public void itShouldGetItemBankUserWhenAuthenticationIsNull() {
         final ItemBankUser user = spy.getItemBankUser(null);
         assertThat(user.getUsername()).isEqualTo(USER_ANONYMOUS);

--- a/src/test/java/org/opentestsystem/ap/ims/util/SystemExceptionTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/SystemExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SystemExceptionTest {
+
+    @Test
+    public void itShouldCreateInstanceUsingNoArgConstructor() {
+        new SystemException();
+    }
+
+    @Test
+    public void itShouldCreateInstanceUsingOnlyMessage() {
+        final SystemException systemException = new SystemException("validation error");
+        assertThat(systemException.getMessage()).isEqualTo("validation error");
+    }
+
+    @Test
+    public void itShouldCreateInstanceUsingExistingThrowableWithNullErrorMessage() {
+        IOException ioException = new IOException("IO Error");
+        final SystemException systemException = new SystemException(ioException);
+        assertThat(systemException.getMessage()).contains("IO Error");
+        assertThat(systemException.getCause()).isEqualTo(ioException);
+    }
+
+    @Test
+    public void itShouldCreateInstanceUsingExistingThrowable() {
+        IOException ioException = new IOException("IO Error");
+        final SystemException systemException = new SystemException("validation error", ioException);
+        assertThat(systemException.getMessage()).isEqualTo("validation error");
+        assertThat(systemException.getCause()).isEqualTo(ioException);
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/util/ValidationExceptionTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/ValidationExceptionTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidationExceptionTest {
+
+    @Test
+    public void itShouldCreateInstanceUsingOnlyMessage() {
+        final ValidationException validationException = new ValidationException("validation error");
+        assertThat(validationException.getMessage()).isEqualTo("validation error");
+    }
+
+    @Test
+    public void itShouldCreateInstanceUsingExistingThrowable() {
+        IOException ioException = new IOException("IO Error");
+        final ValidationException validationException = new ValidationException("validation error", ioException);
+        assertThat(validationException.getMessage()).isEqualTo("validation error");
+        assertThat(validationException.getCause()).isEqualTo(ioException);
+    }
+}

--- a/src/test/java/org/opentestsystem/saaif/item/ItemFactoryTest.java
+++ b/src/test/java/org/opentestsystem/saaif/item/ItemFactoryTest.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.saaif.item;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemAttribute.ItemId;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemLanguage.LANG_ENU;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemLanguage.LANG_ESN;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemPageLayout.PAGE_LAYOUT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemResponseType.RESPONSE_TYPE_HTML_EDITOR;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemVersion.ITEM_RELEASE_VERSION;
+import static org.opentestsystem.saaif.item.ItemConstants.ItemVersion.ITEM_VERSION;
+import static org.opentestsystem.saaif.item.ItemTestUtil.TEST_ITEM_ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ItemFactoryTest {
+
+    private ItemFactory itemFactory;
+
+    private ItemFactory spyItemFactory;
+
+    @Before
+    public void setup() {
+        itemFactory = new ItemFactory();
+        spyItemFactory = Mockito.spy(itemFactory);
+    }
+
+    @Test
+    public void itShouldCreateNewAssessmentItem() {
+        final ItemRelease.Item shortAnswer = itemFactory.newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+        doReturn(shortAnswer).when(spyItemFactory).newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+
+        final ItemRelease assessmentItem = spyItemFactory.newAssessmentItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+        assertThat(assessmentItem.getItem()).isEqualTo(shortAnswer);
+        assertThat(assessmentItem.getVersion()).isEqualTo(ITEM_RELEASE_VERSION);
+    }
+
+    @Test
+    public void itShouldCreateNewItemForShortAnswer() {
+        final ItemRelease.Item shortAnswerItem = itemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
+
+        doReturn(shortAnswerItem).when(spyItemFactory).newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
+
+        final ItemRelease.Item item = spyItemFactory.newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+        assertThat(item).isEqualTo(shortAnswerItem);
+    }
+
+    @Test
+    public void itShouldCreateNullNewItem() {
+        final ItemRelease.Item item = itemFactory.newItem(TEST_ITEM_ID, "not-real", LANG_ENU);
+        assertThat(item).isNull();
+    }
+
+    @Test
+    public void itShouldCreateShortAnswerItem() {
+        final ItemRelease.Item.Content content = itemFactory.newContent(LANG_ENU);
+
+        final ItemRelease.Item.Attriblist attriblist = itemFactory.newItemAttributeList(TEST_ITEM_ID,
+            FORMAT_SHORT_ANSWER, PAGE_LAYOUT_SHORT_ANSWER, RESPONSE_TYPE_HTML_EDITOR);
+
+        doReturn(attriblist).when(spyItemFactory).newItemAttributeList(TEST_ITEM_ID,
+            FORMAT_SHORT_ANSWER, PAGE_LAYOUT_SHORT_ANSWER, RESPONSE_TYPE_HTML_EDITOR);
+
+        doReturn(content).when(spyItemFactory).newContent(LANG_ENU);
+
+        final ItemRelease.Item shortAnswerItem = spyItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
+
+        assertThat(shortAnswerItem.getId()).isEqualTo(TEST_ITEM_ID);
+        assertThat(shortAnswerItem.getFormat()).isEqualTo(FORMAT_SHORT_ANSWER);
+        assertThat(shortAnswerItem.getVersion()).isEqualTo(ITEM_VERSION);
+        assertThat(shortAnswerItem.getAttriblist()).isEqualTo(attriblist);
+        assertThat(shortAnswerItem.getContent()).hasSize(1);
+        assertThat(shortAnswerItem.getContent().get(0)).isEqualTo(content);
+
+        final ItemRelease.Item shortAnswerItem2 = spyItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU, LANG_ESN);
+        assertThat(shortAnswerItem2.getContent()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldCreateNewContent() {
+        final ItemRelease.Item.Content content = itemFactory.newContent(LANG_ENU);
+        assertThat(content.getLanguage()).isEqualTo(LANG_ENU);
+        assertThat(content.getVersion()).isEqualTo(ITEM_RELEASE_VERSION);
+        assertThat(content.getStem()).isEqualTo(EMPTY);
+    }
+
+    @Test
+    public void itShouldCreateNewItemAttributeList() {
+        final List<String> values = Lists.newArrayList("itemId", "SA", "8", "PlainText");
+
+        final ItemRelease.Item.Attriblist attriblist = itemFactory.newItemAttributeList("itemId", "sa", "8", "PlainText");
+        assertThat(attriblist).isNotNull();
+
+        final List<ItemRelease.Item.Attriblist.Attrib> attribs = attriblist.getAttrib();
+        assertThat(attribs).hasSize(5);
+
+        final List<String> attIds = Arrays.stream(ItemConstants.ItemAttribute.values()).map(ItemConstants
+            .ItemAttribute::getAttId).collect(Collectors.toList());
+        final List<String> attNames = Arrays.stream(ItemConstants.ItemAttribute.values()).map(ItemConstants
+            .ItemAttribute::getName).collect(Collectors.toList());
+
+        for (ItemRelease.Item.Attriblist.Attrib attrib: attribs) {
+            assertThat(attrib.getAttid()).isIn(attIds);
+            assertThat(attrib.getName()).isIn(attNames);
+            assertThat(attrib.getVal()).isIn(values);
+        }
+    }
+
+    @Test
+    public void itShouldCreateNewAttributeUsingItemAttribute() {
+        final ItemRelease.Item.Attriblist.Attrib attrib = itemFactory.newAttribute(ItemId, "val");
+        assertThat(attrib.getAttid()).isEqualTo(ItemId.getAttId());
+        assertThat(attrib.getName()).isEqualTo(ItemId.getName());
+        assertThat(attrib.getVal()).isEqualTo("val");
+    }
+
+    @Test
+    public void itShouldCreateNewAttribute() {
+        final ItemRelease.Item.Attriblist.Attrib attrib = itemFactory.newAttribute("attId", "name", "val");
+        assertThat(attrib.getAttid()).isEqualTo("attId");
+        assertThat(attrib.getName()).isEqualTo("name");
+        assertThat(attrib.getVal()).isEqualTo("val");
+    }
+}

--- a/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
+++ b/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
@@ -47,7 +47,7 @@ public class ItemReleaseTest {
     @Test
     public void itShouldCreateAndMarshalMinimumShortAnswerToXml() throws Exception {
         // confirm the factory creates the minimum object as expected
-        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(itemId, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(itemId, FORMAT_SHORT_ANSWER, LANG_ENU);
 
         assertThat(shortAnswer).isNotNull();
         assertThat(shortAnswer.getItem()).isNotNull();

--- a/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
+++ b/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
@@ -47,7 +47,7 @@ public class ItemReleaseTest {
     @Test
     public void itShouldCreateAndMarshalMinimumShortAnswerToXml() throws Exception {
         // confirm the factory creates the minimum object as expected
-        final ItemRelease shortAnswer = FACTORY.newMinimumItemWrapper(itemId, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(itemId, FORMAT_SHORT_ANSWER);
 
         assertThat(shortAnswer).isNotNull();
         assertThat(shortAnswer.getItem()).isNotNull();

--- a/src/test/java/org/opentestsystem/saaif/item/ItemTestUtil.java
+++ b/src/test/java/org/opentestsystem/saaif/item/ItemTestUtil.java
@@ -124,34 +124,6 @@ public class ItemTestUtil {
         return marshaller;
     }
 
-//    public static ObjectMapper createJaxbObjectMapper() {
-//        final ObjectMapper mapper = new ObjectMapper();
-//        final TypeFactory typeFactory = TypeFactory.defaultInstance();
-//        final AnnotationIntrospector introspector = new JaxbAnnotationIntrospector(typeFactory);
-//        // make deserializer use JAXB annotations (only)
-//        mapper.getDeserializationConfig().with(introspector);
-//        // make serializer use JAXB annotations (only)
-//        mapper.getSerializationConfig().with(introspector);
-//        return mapper;
-//    }
-//
-//    public static void writeJsonSchemaToStandardOut(
-//        final String fullyQualifiedClassName) {
-//        final SchemaFactoryWrapper visitor = new SchemaFactoryWrapper();
-//        final ObjectMapper mapper = new ObjectMapper();
-//        try {
-//            mapper.acceptJsonFormatVisitor(mapper.constructType(Class.forName(fullyQualifiedClassName)), visitor);
-//            final com.fasterxml.jackson.module.jsonSchema.JsonSchema jsonSchema = visitor.finalSchema();
-//            out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonSchema));
-//        } catch (ClassNotFoundException cnfEx) {
-//            err.println("Unable to find class " + fullyQualifiedClassName);
-//        } catch (JsonMappingException jsonEx) {
-//            err.println("Unable to map JSON: " + jsonEx);
-//        } catch (JsonProcessingException jsonEx) {
-//            err.println("Unable to process JSON: " + jsonEx);
-//        }
-//    }
-
     /**
      * Converts a file to a string.  The file should be on the classpath as this specifically
      * looks for system resource from the <code>ClassLoader</code>.

--- a/src/test/resources/application-it-test.yml
+++ b/src/test/resources/application-it-test.yml
@@ -1,6 +1,6 @@
 # --------------------------------------------------------
 # Properties for integration tests.  Tests are run with an
-# active profile of 'test'
+# active profile of 'it-test'
 # --------------------------------------------------------
 security:
   basic:
@@ -12,4 +12,12 @@ spring:
 
 itembank:
   test:
+    enabled: "true"
+
+---
+spring:
+  profiles: "security-on"
+
+security:
+  basic:
     enabled: "true"


### PR DESCRIPTION
The scratch pad branch now uses the username property of the principal object which is the user's email address.  Git branches can have @ and . in them so an email address is a valid Git branch name.

I remove the @Repository and @Service annotations and replaced them with @Component.  Given we are not transacting with a database like MySql (at least yet) it doesn't make sense to use those annotations as they add unnecessary overhead.

There is no need to create the empty README.md like I was previously doing so we no longer are.  The master branch at the end of 'create item' is empty and only the scratch pad branch has the item's data file.