### PR TITLE
Feature/iat 400

### DIFF
--- a/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.opentestsystem.ap.ims.client;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,7 +55,7 @@ import static java.lang.System.out;
  * It is expected one will use {@link GitClientFactory} to instantiate an instance of this
  * class.  The name of the repository to work with is given to the factory.  Once there
  * is an instance of this class it can be used to interact with that repository.  The
- * main point is an instance of htis class is not stateless.  If you need to work with two different
+ * main point is an instance of this class is not stateless.  If you need to work with two different
  * repositories you need create two different instances of this class.
  * </p>
  * <p>

--- a/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitClient.java
@@ -16,6 +16,14 @@
 
 package org.opentestsystem.ap.ims.client;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -23,10 +31,8 @@ import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RefSpec;
@@ -36,16 +42,6 @@ import org.opentestsystem.ap.ims.entity.ItemBankUser;
 import org.opentestsystem.ap.ims.util.ItemAssembler;
 import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemRelease;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 
 import static java.lang.System.out;
 
@@ -191,9 +187,8 @@ public class GitClient {
      * Pushes local pending commits to the remote repository.
      */
     public void push() {
-        final PushCommand push = git.push();
         try {
-            push.setCredentialsProvider(credentialsProvider).call();
+            git.push().setCredentialsProvider(credentialsProvider).call();
         } catch (GitAPIException e) {
             throw new SystemException("Error pushing changes", e);
         }
@@ -361,26 +356,6 @@ public class GitClient {
         } catch (GitAPIException e) {
             throw new SystemException("Error checking out branch " + branchName, e);
         }
-    }
-
-    private boolean checkScratchPadBranchExist() {
-        boolean exists = false;
-        Collection<Ref> heads = Collections.emptyList();
-        try {
-            heads = git.lsRemote().setCredentialsProvider(credentialsProvider).setHeads(true).call();
-            if (heads != null && !heads.isEmpty()) {
-                for (Ref head : heads) {
-                    out.println(head.getName());
-                    if (head.getName().endsWith(SCRATCH_PAD)) {
-                        exists = true;
-                        break;
-                    }
-                }
-            }
-        } catch (GitAPIException e) {
-            throw new SystemException("Problem calling ls-remote on repository", e);
-        }
-        return exists;
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/ims/client/GitlabClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitlabClient.java
@@ -27,7 +27,6 @@ import org.gitlab.api.models.GitlabSession;
 import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.util.SystemException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 /**
  * A client into Gitlab.  The client is configured with a group.  The group
@@ -36,10 +35,9 @@ import org.springframework.stereotype.Component;
  * under the configured group.
  */
 @Slf4j
-@Component
 public class GitlabClient {
 
-    private final ItemBankProperties gitlabProperties;
+    protected final ItemBankProperties gitlabProperties;
 
     private GitlabSession gitlabSession;
 

--- a/src/main/java/org/opentestsystem/ap/ims/client/GitlabClient.java
+++ b/src/main/java/org/opentestsystem/ap/ims/client/GitlabClient.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.opentestsystem.ap.ims.client;
+
+import java.io.IOException;
+import javax.annotation.PostConstruct;
+
+import lombok.extern.slf4j.Slf4j;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.http.GitlabHTTPRequestor;
+import org.gitlab.api.models.GitlabGroup;
+import org.gitlab.api.models.GitlabProject;
+import org.gitlab.api.models.GitlabSession;
+import org.opentestsystem.ap.ims.config.ItemBankProperties;
+import org.opentestsystem.ap.ims.util.SystemException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * A client into Gitlab.  The client is configured with a group.  The group
+ * is the top level where all items (or projects) are created and assumed
+ * to live.  For example, looking up a project expects the project to be
+ * under the configured group.
+ */
+@Slf4j
+@Component
+public class GitlabClient {
+
+    private final ItemBankProperties gitlabProperties;
+
+    private GitlabSession gitlabSession;
+
+    private GitlabAPI gitlabApi;
+
+    private GitlabGroup gitlabGroup;
+
+    private String gitLabProjectLookupBaseUrl;
+
+    @Autowired
+    public GitlabClient(final ItemBankProperties gitlabProperties) {
+        this.gitlabProperties = gitlabProperties;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        setGitlabSession(createSession());
+
+        setGitlabApi(createGitlabAPI());
+
+        final GitlabGroup gitlabGroup = lookupGroup();
+        setGitlabGroup(gitlabGroup);
+
+        setGitLabProjectLookupBaseUrl(GitlabProject.URL + "/" + gitlabProperties.getGroup() + "%2F");
+    }
+
+    public GitlabProject createProject(String itemId) {
+        final GitlabProject project;
+        try {
+            // using deprecated method, only way to create project under group
+            project = gitlabApi.createProject(
+                (String) itemId,                    // name
+                (Integer) gitlabGroup.getId(),      // namespaceId
+                (String) null,                      // description
+                Boolean.TRUE,                       // issuesEnabled
+                Boolean.FALSE,                      // wallEnabled
+                Boolean.FALSE,                      // mergeRequestsEnabled
+                Boolean.FALSE,                      // wikiEnabled
+                Boolean.FALSE,                      // snippetsEnabled
+                Boolean.FALSE,                      // publik
+                0,                                  // visibilityLevel
+                (String) null                       // importUrl
+            );
+        } catch (IOException e) {
+            throw new SystemException("Error creating Gitlab project", e);
+        }
+        return project;
+    }
+
+    /**
+     * Delete's a project from gitlab.
+     *
+     * @param projectName The project to delete.
+     */
+    public void deleteProject(String projectName) {
+        final GitlabProject gitlabProject = lookupProjectByName(projectName);
+        if (gitlabProject != null) {
+            try {
+                gitlabApi.deleteProject(gitlabProject.getId());
+            } catch (IOException e) {
+                throw new SystemException("Error deleting Gitlab project " + projectName, e);
+            }
+        }
+    }
+
+    /**
+     * Look up the gitlab project by its name.
+     *
+     * @param projectName The Gitlab project name.
+     * @return The Gitlab project.
+     */
+    public GitlabProject lookupProjectByName(final String projectName) {
+        log.debug("looking up  project {}", projectName);
+        final GitlabHTTPRequestor requestor = gitlabApi.retrieve();
+        final String projectUrl = gitLabProjectLookupBaseUrl + projectName;
+        GitlabProject project = null;
+        try {
+            project = requestor.to(projectUrl, GitlabProject.class);
+        } catch (IOException e) {
+            throw new SystemException("Error looking up Gitlab project " + projectName, e);
+        }
+        return project;
+    }
+
+    /**
+     * Looks up the Gitlab group configured for the application.
+     *
+     * @return The Gitlab group.
+     */
+    public GitlabGroup lookupGroup() {
+        final String groupName = gitlabProperties.getGroup();
+        log.debug("getting group {}", groupName);
+        try {
+            return gitlabApi.getGroup(groupName);
+        } catch (IOException e) {
+            throw new SystemException("Error looking up Gitlab group " + groupName, e);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Private
+    // ------------------------------------------------------------------------
+
+    GitlabSession createSession() {
+        try {
+            return GitlabAPI.connect(gitlabProperties.getHost(), gitlabProperties.getUser(), gitlabProperties
+                .getPassword());
+        } catch (IOException e) {
+            String errorMsg = String.format("Error creating a session with Gitlab [host:%s][user:%s]",
+                gitlabProperties.getHost(), gitlabProperties.getUser());
+            throw new SystemException(errorMsg);
+        }
+    }
+
+    GitlabAPI createGitlabAPI() {
+        return GitlabAPI.connect(gitlabProperties.getHost(), gitlabSession.getPrivateToken());
+    }
+
+    // ------------------------------------------------------------------------
+    // Getters / Setters
+    // ------------------------------------------------------------------------
+
+    public void setGitlabGroup(GitlabGroup group) {
+        this.gitlabGroup = group;
+    }
+
+    public void setGitlabSession(GitlabSession gitlabSession) {
+        this.gitlabSession = gitlabSession;
+    }
+
+    public void setGitlabApi(GitlabAPI gitlabApi) {
+        this.gitlabApi = gitlabApi;
+    }
+
+    public void setGitLabProjectLookupBaseUrl(String gitLabProjectLookupBaseUrl) {
+        this.gitLabProjectLookupBaseUrl = gitLabProjectLookupBaseUrl;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/ims/config/ItemBankProperties.java
+++ b/src/main/java/org/opentestsystem/ap/ims/config/ItemBankProperties.java
@@ -45,6 +45,5 @@ public class ItemBankProperties {
 
     private String localBaseDir;
 
-    private String initialCommitMessage = "initial commit";
 
 }

--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemBankRepository.java
@@ -15,24 +15,16 @@
  */
 package org.opentestsystem.ap.ims.repository;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
-import org.gitlab.api.GitlabAPI;
-import org.gitlab.api.models.GitlabGroup;
-import org.gitlab.api.models.GitlabProject;
-import org.gitlab.api.models.GitlabSession;
 import org.opentestsystem.ap.ims.client.GitClient;
 import org.opentestsystem.ap.ims.client.GitClientFactory;
+import org.opentestsystem.ap.ims.client.GitlabClient;
 import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.entity.ItemBankUser;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
-import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemRelease;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
-import java.io.IOException;
 
 /**
  * Item bank GitLab repository implementation.
@@ -43,33 +35,21 @@ public class ItemBankRepository {
 
     private final ItemBankProperties itemBankProperties;
 
-    private final GitlabSession gitlabSession;
-
     private final ItemIdGenerator itemIdGenerator;
+
+    private final GitlabClient gitlabClient;
 
     private final GitClientFactory gitClientFactory;
 
-    private GitlabAPI gitlabApi;
-
-    private GitlabGroup group;
-
     @Autowired
-    public ItemBankRepository(ItemBankProperties itemBankProperties,
-                              GitlabSession gitlabSession,
-                              ItemIdGenerator itemIdGenerator,
-                              GitClientFactory gitClientFactory) {
+    public ItemBankRepository(final ItemBankProperties itemBankProperties,
+                              final GitlabClient gitlabClient,
+                              final ItemIdGenerator itemIdGenerator,
+                              final GitClientFactory gitClientFactory) {
         this.itemBankProperties = itemBankProperties;
-        this.gitlabSession = gitlabSession;
+        this.gitlabClient = gitlabClient;
         this.itemIdGenerator = itemIdGenerator;
         this.gitClientFactory = gitClientFactory;
-    }
-
-    @PostConstruct
-    public void initialize() {
-        if (gitlabSession != null && gitlabSession.getPrivateToken() != null) {
-            gitlabApi = GitlabAPI.connect(itemBankProperties.getHost(), gitlabSession.getPrivateToken());
-            group = lookupGroup();
-        }
     }
 
     /**
@@ -84,11 +64,10 @@ public class ItemBankRepository {
 
         final String itemId = itemIdGenerator.generateItemId();
 
-        final GitlabGroup group = getGroup();
-        createProject(group, itemId);
+        gitlabClient.createProject(itemId);
 
         final GitClient cli = gitClientFactory.cloneRemoteRepository(user, itemId);
-        cli.commit(itemBankProperties.getInitialCommitMessage());
+        cli.commit("initial commit");
         cli.push();
 
         return itemId;
@@ -132,66 +111,14 @@ public class ItemBankRepository {
         cli.deleteScratchPad();
     }
 
-    // ------------------------------------------------------------------------
-
     /**
-     * Creates a new project in Gitlab.
+     * Delete's an item from the item bank.
      *
-     * @param group    The group to associate the project with.
-     * @param itemName The name of the new project.
-     * @return The new Gitlab project.
+     * @param user   The user making the request.
+     * @param itemId The item to delete.
      */
-    @VisibleForTesting
-    GitlabProject createProject(GitlabGroup group, String itemName) {
-        final GitlabProject project;
-        try {
-            project = gitlabApi.createProject(
-                (String) itemName,            // name
-                (Integer) group.getId(),    // namespaceId
-                (String) null,              // description
-                Boolean.TRUE,               // issuesEnabled
-                Boolean.FALSE,               // wallEnabled
-                Boolean.FALSE,               // mergeRequestsEnabled
-                Boolean.FALSE,               // wikiEnabled
-                Boolean.FALSE,               // snippetsEnabled
-                Boolean.FALSE,              // publik
-                0,                          // visibilityLevel
-                (String) null               // importUrl
-            );
-        } catch (IOException e) {
-            throw new SystemException("Error creating project", e);
-        }
-        return project;
-    }
-
-    /**
-     * Looks up the configured Gitlab group.
-     *
-     * @return The Gitlab group.
-     */
-    @VisibleForTesting
-    GitlabGroup lookupGroup() {
-        log.debug("getting group {}", itemBankProperties.getGroup());
-        try {
-            return gitlabApi.getGroup(itemBankProperties.getGroup());
-        } catch (IOException e) {
-            throw new SystemException("Error looking up Gitlab Group", e);
-        }
-    }
-
-    /**
-     * Looks up the configured Gitlab group.
-     *
-     * @return The Gitlab group.
-     */
-    @VisibleForTesting
-    GitlabGroup getGroup() {
-        return group;
-    }
-
-    @VisibleForTesting
-    void setGitlabApi(GitlabAPI gitlabApi) {
-        this.gitlabApi = gitlabApi;
+    public void deleteItem(ItemBankUser user, String itemId) {
+        gitlabClient.deleteProject(itemId);
     }
 
 }

--- a/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
+++ b/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.opentestsystem.ap.ims.entity.Item;
 import org.opentestsystem.ap.ims.service.ItemBankService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -78,5 +79,16 @@ public class ItemApi {
     public void commitChanges(@PathVariable String itemId) {
         itemBankService.commitItemChanges(itemId);
     }
+
+    /**
+     * Delete's an item from the item bank.
+     *
+     * @param itemId The item to delete.
+     */
+    @DeleteMapping("/{itemId}")
+    public void deleteItem(@PathVariable String itemId) {
+        itemBankService.deleteItem(itemId);
+    }
+
 
 }

--- a/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
+++ b/src/main/java/org/opentestsystem/ap/ims/service/ItemBankService.java
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.opentestsystem.ap.ims.service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -69,10 +68,10 @@ public class ItemBankService {
     public void updateItem(String itemId, Item item) {
         log.debug("");
         if (StringUtils.isBlank(itemId)) {
-            throw new ValidationException("Item ID is required when updating an item");
+            throw new ValidationException("Item ID is required");
         }
         if (item == null) {
-            throw new ValidationException("Item is required qhen updating an item");
+            throw new ValidationException("Item is required");
         }
         final ItemBankUser user = securityUtil.getItemBankUser();
     }
@@ -86,10 +85,23 @@ public class ItemBankService {
      */
     public void commitItemChanges(String itemId) {
         if (StringUtils.isBlank(itemId)) {
-            throw new ValidationException("Item ID is required when merging an item");
+            throw new ValidationException("Item ID is required");
         }
         final ItemBankUser user = securityUtil.getItemBankUser();
         itemBankRepository.commitItemChanges(user, itemId);
 
+    }
+
+    /**
+     * Delete's an item from the item bank.
+     *
+     * @param itemId The item to delete.
+     */
+    public void deleteItem(String itemId) {
+        if (StringUtils.isBlank(itemId)) {
+            throw new ValidationException("Item ID is required");
+        }
+        final ItemBankUser user = securityUtil.getItemBankUser();
+        itemBankRepository.deleteItem(user, itemId);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
@@ -15,14 +15,17 @@
  */
 package org.opentestsystem.ap.ims.client;
 
+import java.io.File;
+import java.nio.file.Files;
+
 import org.eclipse.jgit.api.CheckoutCommand;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.CommitCommand;
+import org.eclipse.jgit.api.CreateBranchCommand;
 import org.eclipse.jgit.api.DeleteBranchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
 import org.eclipse.jgit.api.PushCommand;
-import org.eclipse.jgit.api.errors.CheckoutConflictException;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidConfigurationException;
 import org.eclipse.jgit.lib.Repository;
@@ -41,15 +44,11 @@ import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemFactory;
 import org.opentestsystem.saaif.item.ItemRelease;
 
-import java.io.File;
-import java.nio.file.Files;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -67,6 +66,9 @@ import static org.opentestsystem.saaif.item.ItemConstants.ItemFormat.FORMAT_SHOR
 public class GitClientTest {
 
     private static final ItemFactory FACTORY = new ItemFactory();
+
+    @Mock
+    private InvalidConfigurationException mockException;
 
     @Mock
     private Git mockGit;
@@ -98,6 +100,9 @@ public class GitClientTest {
     @Mock
     private RefSpec mockRefSpec;
 
+    @Mock
+    private CreateBranchCommand mockCreateBranchCommand;
+
     private GitClient spyGitClient;
 
     private GitClient gitClient;
@@ -128,6 +133,37 @@ public class GitClientTest {
 
     // ------------------------------------------------------------------------
 
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenCreatingScratchPadBranch() throws GitAPIException {
+        final String username = ITEM_BANK_USER.getUsername();
+
+        when(mockGit.branchCreate()).thenReturn(mockCreateBranchCommand);
+        when(mockCreateBranchCommand.setName(username)).thenReturn(mockCreateBranchCommand);
+        when(mockCreateBranchCommand.call()).thenThrow(mockException);
+
+        gitClient.createScratchPad();
+    }
+
+    @Test
+    public void itShouldCreateScratchPadBranch() throws GitAPIException {
+        final String username = ITEM_BANK_USER.getUsername();
+
+        when(mockGit.branchCreate()).thenReturn(mockCreateBranchCommand);
+        when(mockCreateBranchCommand.setName(username)).thenReturn(mockCreateBranchCommand);
+
+        when(mockGit.checkout()).thenReturn(mockCheckoutCommand);
+        when(mockCheckoutCommand.setName(username)).thenReturn(mockCheckoutCommand);
+
+        gitClient.createScratchPad();
+
+        verify(mockGit, times(1)).branchCreate();
+        verify(mockCreateBranchCommand, times(1)).setName(username);
+        verify(mockCreateBranchCommand, times(1)).call();
+
+        verify(mockGit, times(1)).checkout();
+        verify(mockCheckoutCommand, times(1)).setName(username);
+        verify(mockCheckoutCommand, times(1)).call();
+    }
 
     @Test
     public void itShouldDeleteScratchPad() {
@@ -142,8 +178,6 @@ public class GitClientTest {
 
     @Test(expected = SystemException.class)
     public void itShouldThrowSystemExceptionWhenDeletingRemoteBranch() throws GitAPIException {
-        final InvalidConfigurationException mockException = mock(InvalidConfigurationException.class);
-
         doReturn(mockRefSpec).when(spyGitClient).newRefSpec();
 
         when(mockRefSpec.setSource(null)).thenReturn(mockRefSpec);
@@ -186,8 +220,6 @@ public class GitClientTest {
 
     @Test(expected = SystemException.class)
     public void itShouldThrowSystemExceptionWhenDeletingLocalBranch() throws GitAPIException {
-        final InvalidConfigurationException mockException = mock(InvalidConfigurationException.class);
-
         when(mockGit.branchDelete()).thenReturn(mockDeleteBranchCommand);
         when(mockDeleteBranchCommand.setBranchNames(ITEM_BANK_USER.getUsername())).thenReturn(mockDeleteBranchCommand);
         when(mockDeleteBranchCommand.setForce(true)).thenReturn(mockDeleteBranchCommand);
@@ -221,7 +253,6 @@ public class GitClientTest {
     @Test(expected = SystemException.class)
     public void itShouldThrowSystemExceptionWhenPullingRemoteBranchIntoCurrentLocal() throws GitAPIException {
         final String branchName = "test-branch";
-        final InvalidConfigurationException mockException = mock(InvalidConfigurationException.class);
 
         when(mockGit.pull()).thenReturn(mockPullCommand);
         when(mockPullCommand.setCredentialsProvider(any(UsernamePasswordCredentialsProvider.class)))
@@ -246,8 +277,6 @@ public class GitClientTest {
 
     @Test(expected = SystemException.class)
     public void itShouldThrowSystemExceptionWhenPullingLatest() throws GitAPIException {
-        final InvalidConfigurationException mockException = mock(InvalidConfigurationException.class);
-
         when(mockGit.pull()).thenReturn(mockPullCommand);
         when(mockPullCommand.setCredentialsProvider(any(UsernamePasswordCredentialsProvider.class)))
             .thenReturn(mockPullCommand);
@@ -284,8 +313,6 @@ public class GitClientTest {
 
     @Test(expected = SystemException.class)
     public void itShouldThrowSystemExceptionWhenCheckingOutBranchByName() throws GitAPIException {
-        final CheckoutConflictException mockException = mock(CheckoutConflictException.class);
-
         when(mockGit.checkout()).thenReturn(mockCheckoutCommand);
         when(mockCheckoutCommand.setName(ITEM_ID)).thenReturn(mockCheckoutCommand);
         when(mockCheckoutCommand.call()).thenThrow(mockException);
@@ -357,6 +384,16 @@ public class GitClientTest {
         verify(mockCloneCommand, times(1)).call();
     }
 
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenPushing() throws GitAPIException {
+        when(mockGit.push()).thenReturn(mockPushCommand);
+        when(mockPushCommand.setCredentialsProvider(any(UsernamePasswordCredentialsProvider.class))).thenReturn
+            (mockPushCommand);
+        when(mockPushCommand.call()).thenThrow(mockException);
+
+        gitClient.push();
+    }
+
     @Test
     public void itShouldPush() throws GitAPIException {
         when(mockPushCommand.setCredentialsProvider(any(UsernamePasswordCredentialsProvider.class))).thenReturn
@@ -367,6 +404,17 @@ public class GitClientTest {
 
         verify(mockPushCommand, times(1)).setCredentialsProvider(any(UsernamePasswordCredentialsProvider.class));
         verify(mockPushCommand, times(1)).call();
+    }
+
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenCommitting() throws GitAPIException {
+        final String message = "Test Commit Message";
+
+        when(mockGit.commit()).thenReturn(mockCommitCommand);
+        when(mockCommitCommand.setMessage(message)).thenReturn(mockCommitCommand);
+        when(mockCommitCommand.call()).thenThrow(mockException);
+
+        gitClient.commit(message);
     }
 
     @Test
@@ -431,6 +479,4 @@ public class GitClientTest {
         verify(mockConfig, times(1)).setString(GIT_CONFIG_USER, null, GIT_CONFIG_USER_EMAIL, ITEM_BANK_USER
             .getUsername());
     }
-
-
 }

--- a/src/test/java/org/opentestsystem/ap/ims/client/GitlabClientTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/client/GitlabClientTest.java
@@ -1,0 +1,202 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.opentestsystem.ap.ims.client;
+
+import java.io.IOException;
+
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.http.GitlabHTTPRequestor;
+import org.gitlab.api.models.GitlabGroup;
+import org.gitlab.api.models.GitlabProject;
+import org.gitlab.api.models.GitlabSession;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.ims.config.ItemBankProperties;
+import org.opentestsystem.ap.ims.util.ItemBankTestUtil;
+import org.opentestsystem.ap.ims.util.SystemException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.GROUP_ID;
+import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_ID;
+import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.PROJECT_ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GitlabClientTest {
+
+    private final ItemBankTestUtil TEST_UTIL = new ItemBankTestUtil();
+
+    private final IOException ioException = new IOException("IO Error");
+
+    @Mock
+    private ItemBankProperties mockGitlabProperties;
+
+    @Mock
+    private GitlabSession mockGitLabSession;
+
+    @Mock
+    private GitlabAPI mockGitlabApi;
+
+    @Mock
+    private GitlabGroup mockGitlabGroup;
+
+    @Mock
+    private GitlabHTTPRequestor mockGitlabRequestor;
+
+    @Mock
+    private GitlabProject mockGitlabProject;
+
+    private String gitLabProjectLookupBaseUrl;
+
+    private ItemBankProperties props;
+
+    private GitlabClient gitlabClient;
+
+    private GitlabClient spyGitlabClient;
+
+    @Before
+    public void setup() throws IOException {
+        props = TEST_UTIL.getGitlabProperties();
+
+        gitLabProjectLookupBaseUrl = GitlabProject.URL + "/" + props.getGroup() + "%2F";
+
+        gitlabClient = new GitlabClient(mockGitlabProperties);
+        gitlabClient.setGitlabSession(mockGitLabSession);
+        gitlabClient.setGitlabApi(mockGitlabApi);
+        gitlabClient.setGitlabGroup(mockGitlabGroup);
+        gitlabClient.setGitLabProjectLookupBaseUrl(gitLabProjectLookupBaseUrl);
+
+        spyGitlabClient = spy(gitlabClient);
+
+        when(mockGitlabProperties.getGroup()).thenReturn(props.getGroup());
+        when(mockGitlabProperties.getHost()).thenReturn(props.getHost());
+        when(mockGitlabProperties.getUser()).thenReturn(props.getUser());
+        when(mockGitlabProperties.getPassword()).thenReturn(props.getPassword());
+
+        when(mockGitlabApi.getGroup(props.getGroup())).thenReturn(mockGitlabGroup);
+
+        when(mockGitlabGroup.getId()).thenReturn(GROUP_ID);
+    }
+
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenCreatingSession() {
+        gitlabClient.createSession();
+    }
+
+    @Test
+    public void itShouldCreateGitlabAPI() {
+        final GitlabAPI gitlabAPI = gitlabClient.createGitlabAPI();
+
+        assertThat(gitlabAPI).isNotNull();
+
+        verify(mockGitlabProperties, times(1)).getHost();
+        verify(mockGitLabSession, times(1)).getPrivateToken();
+    }
+
+    @Test
+    public void itShouldInitialize() {
+        doReturn(mockGitLabSession).when(spyGitlabClient).createSession();
+        doReturn(mockGitlabApi).when(spyGitlabClient).createGitlabAPI();
+        doReturn(mockGitlabGroup).when(spyGitlabClient).lookupGroup();
+
+        spyGitlabClient.initialize();
+
+        verify(spyGitlabClient, times(1)).setGitlabSession(mockGitLabSession);
+        verify(spyGitlabClient, times(1)).setGitlabApi(mockGitlabApi);
+        verify(spyGitlabClient, times(1)).setGitlabGroup(mockGitlabGroup);
+        verify(spyGitlabClient, times(1)).setGitLabProjectLookupBaseUrl(gitLabProjectLookupBaseUrl);
+    }
+
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenDeletingProject() throws IOException {
+        doReturn(mockGitlabProject).when(spyGitlabClient).lookupProjectByName(ITEM_ID);
+        when(mockGitlabProject.getId()).thenReturn(PROJECT_ID);
+
+        doThrow(ioException).when(mockGitlabApi).deleteProject(PROJECT_ID);
+
+        spyGitlabClient.deleteProject(ITEM_ID);
+    }
+
+    @Test
+    public void itShouldDeleteProject() throws IOException {
+        doReturn(mockGitlabProject).when(spyGitlabClient).lookupProjectByName(ITEM_ID);
+        when(mockGitlabProject.getId()).thenReturn(PROJECT_ID);
+
+        spyGitlabClient.deleteProject(ITEM_ID);
+
+        verify(mockGitlabApi, times(1)).deleteProject(PROJECT_ID);
+    }
+
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenLookingUpProjectByName() throws IOException {
+        when(mockGitlabApi.retrieve()).thenReturn(mockGitlabRequestor);
+        when(mockGitlabRequestor.to(gitLabProjectLookupBaseUrl + ITEM_ID, GitlabProject.class)).thenThrow(ioException);
+
+        gitlabClient.lookupProjectByName(ITEM_ID);
+    }
+
+    @Test
+    public void itShouldLookupProjectByName() throws IOException {
+        when(mockGitlabApi.retrieve()).thenReturn(mockGitlabRequestor);
+
+        gitlabClient.lookupProjectByName(ITEM_ID);
+
+        verify(mockGitlabRequestor, times(1)).to(gitLabProjectLookupBaseUrl + ITEM_ID, GitlabProject.class);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test(expected = SystemException.class)
+    public void itShouldThrowSystemExceptionWhenCreatingProject() throws IOException {
+        final IOException ioException = new IOException("IO exception");
+
+        when(mockGitlabApi.createProject(ITEM_ID, GROUP_ID, null,
+            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null))
+            .thenThrow(ioException);
+
+        gitlabClient.createProject(ITEM_ID);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void itShouldCreateProject() throws IOException {
+        gitlabClient.createProject(ITEM_ID);
+
+        verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
+            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
+    }
+
+    @Test(expected = SystemException.class)
+    public void itShouldThrowWhenLookingUpGroup() throws IOException {
+        when(mockGitlabApi.getGroup(props.getGroup())).thenThrow(ioException);
+        final GitlabGroup gitlabGroup = gitlabClient.lookupGroup();
+    }
+
+    @Test
+    public void itShouldLookupGroup() throws IOException {
+        final GitlabGroup gitlabGroup = gitlabClient.lookupGroup();
+        verify(mockGitlabApi, times(1)).getGroup(props.getGroup());
+        verify(mockGitlabProperties, times(1)).getGroup();
+    }
+
+}

--- a/src/test/java/org/opentestsystem/ap/ims/config/GitlabClientStub.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/GitlabClientStub.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2017 Regents of the University of California.
+ *
+ *  Licensed under the Educational Community License, Version 2.0 (the "license");
+ *  you may not use this file except in compliance with the License. You may
+ *  obtain a copy of the license at
+ *
+ *  https://opensource.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opentestsystem.ap.ims.config;
+
+import javax.annotation.PostConstruct;
+
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabGroup;
+import org.gitlab.api.models.GitlabProject;
+import org.gitlab.api.models.GitlabSession;
+import org.opentestsystem.ap.ims.client.GitlabClient;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Replaces the {@link GitlabClient} when running with the
+ * itembank.test.enabled property is set to true.
+ */
+public class GitlabClientStub extends GitlabClient{
+
+    public GitlabClientStub(ItemBankProperties gitlabProperties) {
+        super(gitlabProperties);
+    }
+
+    @Override
+    @PostConstruct
+    public void initialize() {
+        setGitlabSession(mock(GitlabSession.class));
+        setGitlabApi(mock(GitlabAPI.class));
+        setGitlabGroup(mock(GitlabGroup.class));
+        setGitLabProjectLookupBaseUrl(GitlabProject.URL + "/" + gitlabProperties.getGroup() + "%2F");
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/ims/config/ItemBankConfigTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/ItemBankConfigTest.java
@@ -24,11 +24,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
 import org.opentestsystem.saaif.item.ItemFactory;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -42,24 +38,6 @@ public class ItemBankConfigTest {
     @Before
     public void setup() {
         itemBankConfig = new ItemBankConfig(mockItemBankProperties);
-
-    }
-
-    @Test
-    public void itShouldCreateGitlabSession() {
-        when(mockItemBankProperties.getHost()).thenReturn("https://localhost:8080");
-        when(mockItemBankProperties.getUser()).thenReturn("user");
-        when(mockItemBankProperties.getPassword()).thenReturn("password");
-
-        try {
-            itemBankConfig.gitlabSession();
-        } catch (IOException e) {
-            // expected, connection properties are not valid
-        }
-
-        verify(mockItemBankProperties, times(1)).getHost();
-        verify(mockItemBankProperties, times(1)).getUser();
-        verify(mockItemBankProperties, times(1)).getPassword();
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/ims/config/NoItemBankConfig.java
+++ b/src/test/java/org/opentestsystem/ap/ims/config/NoItemBankConfig.java
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.opentestsystem.ap.ims.config;
 
 import org.opentestsystem.ap.ims.client.GitlabClient;
@@ -25,23 +24,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Enabled by default or if the gitlab.enabled property is set to true.  If the property
- * is set to false the configuration is not loaded.
+ * No ItemBank configuration means we are running under a context where
+ * we do not have what is need to connect to an actual Gitlab instance.
+ * This configuration replaces the runtime configuration
  */
 @Configuration
-@ConditionalOnProperty(value = "itembank.test.enabled", havingValue = "false", matchIfMissing = true)
-public class ItemBankConfig {
+@ConditionalOnProperty(value = "itembank.test.enabled", havingValue = "true", matchIfMissing = false)
+public class NoItemBankConfig {
 
     public final ItemBankProperties props;
 
     @Autowired
-    public ItemBankConfig(ItemBankProperties props) {
+    public NoItemBankConfig(ItemBankProperties props) {
         this.props = props;
     }
 
     @Bean
     public GitlabClient gitlabClient() {
-        return new GitlabClient(props);
+        return new GitlabClientStub(props);
     }
 
     @Bean
@@ -53,5 +53,4 @@ public class ItemBankConfig {
     public ItemFactory itemFactory() {
         return new ItemFactory();
     }
-
 }

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemBankRepositoryTest.java
@@ -15,9 +15,8 @@
  */
 package org.opentestsystem.ap.ims.repository;
 
-import org.gitlab.api.GitlabAPI;
-import org.gitlab.api.models.GitlabGroup;
-import org.gitlab.api.models.GitlabSession;
+import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,22 +26,18 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.ims.client.GitClient;
 import org.opentestsystem.ap.ims.client.GitClientFactory;
+import org.opentestsystem.ap.ims.client.GitlabClient;
 import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.util.ItemBankTestUtil;
 import org.opentestsystem.ap.ims.util.ItemIdGenerator;
-import org.opentestsystem.ap.ims.util.SystemException;
 import org.opentestsystem.saaif.item.ItemRelease;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.GROUP_ID;
 import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_FACTORY;
 import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_ID;
@@ -57,16 +52,10 @@ public class ItemBankRepositoryTest {
     private ItemIdGenerator mockItemIdGenerator;
 
     @Mock
-    private GitlabSession mockGitLabSession;
-
-    @Mock
-    private GitlabAPI mockGitlabApi;
+    private GitlabClient mockGitlabClient;
 
     @Mock
     private GitClient mockGitClient;
-
-    @Mock
-    private GitlabGroup mockGroup;
 
     @Mock
     private GitClientFactory mockGitClientFactory;
@@ -78,23 +67,23 @@ public class ItemBankRepositoryTest {
 
     private ItemBankRepository spyRepository;
 
-
     @Before
     public void setup() throws IOException {
         when(mockItemIdGenerator.generateItemId()).thenReturn(ITEM_ID);
-        when(mockGroup.getId()).thenReturn(GROUP_ID);
-        when(mockGitlabApi.getGroup(TEST_UTIL.getGitlabGroup())).thenReturn(mockGroup);
         when(mockGitClientFactory.cloneRemoteRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
         when(mockGitClientFactory.openRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
 
         repository = new ItemBankRepository(
-            TEST_UTIL.getGitlabProperties(), mockGitLabSession, mockItemIdGenerator, mockGitClientFactory);
-
-        repository.setGitlabApi(mockGitlabApi);
+            TEST_UTIL.getGitlabProperties(), mockGitlabClient, mockItemIdGenerator, mockGitClientFactory);
 
         spyRepository = spy(repository);
-        doReturn(mockGroup).when(spyRepository).getGroup();
-        doReturn(mockGroup).when(spyRepository).lookupGroup();
+    }
+
+    @Test
+    public void itShouldDeleteItem() {
+        repository.deleteItem(ITEM_BANK_USER, ITEM_ID);
+
+        verify(mockGitlabClient, times(1)).deleteProject(ITEM_ID);
     }
 
     @Test
@@ -108,23 +97,6 @@ public class ItemBankRepositoryTest {
         inOrder.verify(mockGitClient).mergeScratchPad();
         inOrder.verify(mockGitClient).push();
         inOrder.verify(mockGitClient).deleteScratchPad();
-    }
-
-    @Test
-    public void itShouldInitialize() {
-        repository.initialize();
-
-        when(mockItemBankProperties.getHost()).thenReturn("host");
-        when(mockGitLabSession.getPrivateToken()).thenReturn("token");
-        try {
-            repository.initialize();
-        } catch(Exception e) {
-        }
-    }
-
-    @Test
-    public void itShouldGetGroup() {
-        final GitlabGroup group = repository.getGroup();
     }
 
     @Test
@@ -149,46 +121,14 @@ public class ItemBankRepositoryTest {
         verify(mockGitClient, times(1)).push();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void itShouldInitializeNewItem() throws IOException {
-        final String actualItemId = spyRepository.initializeNewItem(ITEM_BANK_USER);
+        final String actualItemId = repository.initializeNewItem(ITEM_BANK_USER);
 
         assertThat(actualItemId).isEqualTo(ITEM_ID);
 
         verify(mockItemIdGenerator, times(1)).generateItemId();
-
-
-        verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
-            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test(expected = SystemException.class)
-    public void itShouldThrowSystemExceptionWhenCreatingProject() throws IOException {
-        final IOException ioException = new IOException("IO exception");
-
-        when(mockGitlabApi.createProject(ITEM_ID, GROUP_ID, null,
-            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null))
-            .thenThrow(ioException);
-
-        repository.createProject(mockGroup, ITEM_ID);
-
-
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    public void itShouldCreateProject() throws IOException {
-        repository.createProject(mockGroup, ITEM_ID);
-
-        verify(mockGitlabApi, times(1)).createProject(ITEM_ID, GROUP_ID, null,
-            Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, 0, null);
-    }
-
-    @Test
-    public void isShouldLookupGroup() throws IOException {
-        final GitlabGroup gitlabGroup = repository.lookupGroup();
-        verify(mockGitlabApi, times(1)).getGroup(TEST_UTIL.getGitlabGroup());
+        verify(mockGitlabClient, times(1)).createProject(ITEM_ID);
+        verify(mockGitClientFactory, times(1)).cloneRemoteRepository(ITEM_BANK_USER, ITEM_ID);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
@@ -15,6 +15,10 @@
  */
 package org.opentestsystem.ap.ims.rest.v1;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.ap.ims.entity.Item;
@@ -30,10 +34,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.BDDMockito.given;
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.opentestsystem.ap.ims.util.ItemBankTestUtil.ITEM_ID;
 import static org.opentestsystem.saaif.item.ItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -73,6 +74,15 @@ public class ItemApiIT {
 
         assertNotNull("the JSON message converter must not be null",
             this.mappingJackson2HttpMessageConverter);
+    }
+
+    @Test
+    public void itShouldDeleteItemChanges() throws Exception {
+        mvc.perform(delete(API_BASE_PATH + ITEM_ID)
+            .contentType(contentType))
+            .andExpect(status().isOk());
+
+        verify(itemBankService, times(1)).deleteItem(ITEM_ID);
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/service/ItemBankServiceTest.java
@@ -58,6 +58,18 @@ public class ItemBankServiceTest {
         service = new ItemBankService(repository, itemFactory, securityUtil);
     }
 
+    @Test(expected = ValidationException.class)
+    public void itShouldThrowValidationExceptionWhenCallingDeleteItemAndItemIdIsNull() {
+        service.deleteItem(null);
+    }
+
+    @Test
+    public void itShouldDeleteItem() {
+        service.deleteItem(ITEM_ID);
+        verify(securityUtil, times(1)).getItemBankUser();
+        verify(repository, times(1)).deleteItem(ITEM_BANK_USER, ITEM_ID);
+    }
+
     @Test
     public void itShouldCommitItemChanges() {
         service.commitItemChanges(ITEM_ID);

--- a/src/test/java/org/opentestsystem/ap/ims/util/ItemBankTestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/ItemBankTestUtil.java
@@ -15,12 +15,6 @@
  */
 package org.opentestsystem.ap.ims.util;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.opentestsystem.ap.ims.config.ItemBankProperties;
-import org.opentestsystem.ap.ims.entity.ItemBankUser;
-import org.opentestsystem.saaif.item.ItemFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
@@ -28,6 +22,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.ims.config.ItemBankProperties;
+import org.opentestsystem.ap.ims.entity.ItemBankUser;
+import org.opentestsystem.saaif.item.ItemFactory;
 
 /**
  * When instantiated the utility creates a temp directory and another directory in it.
@@ -43,6 +43,8 @@ public class ItemBankTestUtil {
     public static final ItemBankUser ITEM_BANK_USER = new ItemBankUser("test@fake.com", "Test User");
 
     public static final Integer GROUP_ID = 8765309;
+
+    public static final Integer PROJECT_ID = 11;
 
     public static final String ITEM_ID = "test-item";
 


### PR DESCRIPTION
I integrated some of what we discussed today in the parking lot.  I split out of ItemBankRepository all the Gitlab stuff.  There is now a GitlabClient which the ItemBankRepository uses.  It cleaned things up nicely and it made the tests better.  There is almost no package private methods.  One effect of this was it reduced the need to utilize a "spy" when testing.

The new API is -> DELETE /api/v1/items/{itemId}

Executing this method deletes the Gitlab project represented by itemId.