### PR TITLE
IAT-447:  Reordered the sequence of steps when beginning to edit and …

### DIFF
--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemRepository.java
@@ -267,8 +267,8 @@ public class ItemRepository {
         } else if (!isClaimed || (scratchPadOwner != null && !isUserScratchPadOwner)) {
             throw new ValidationException("Item is being edited by " + scratchPadOwner);
         } else if (scratchPadOwner == null) {
-            cli.deleteLocalScratchPad();
             cli.checkoutMasterBranch();
+            cli.deleteLocalScratchPad();
             cli.pullLatest();
             cli.createScratchPad();
             cli.stageItemFile();

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
@@ -171,8 +171,8 @@ public class ItemRepositoryTest {
         inOrder.verify(mockGitClientFactory, times(1)).openRepository(ITEM_BANK_USER, ITEM_ID);
         inOrder.verify(mockGitClient, times(1)).findScratchPadOwner();
         inOrder.verify(mockGitlabClient, times(1)).doesItemFileExistOnMaster(ITEM_ID);
-        inOrder.verify(mockGitClient, times(1)).deleteLocalScratchPad();
         inOrder.verify(mockGitClient, times(1)).checkoutMasterBranch();
+        inOrder.verify(mockGitClient, times(1)).deleteLocalScratchPad();
         inOrder.verify(mockGitClient, times(1)).pullLatest();
         inOrder.verify(mockGitClient, times(1)).createScratchPad();
         inOrder.verify(mockGitClient, times(1)).stageItemFile();


### PR DESCRIPTION
This was easier than expected.  I thought it happened when discarding, but it happened when putting the item in edit mode.

I was able to reproduce this by putting the item in edit mode, going to gitlab and removing the scratch pad branch and the tag (the tag is the lock).  This is effectively like discarding edit changes.  But by doing this I left the local repository on my machine for the item just like it was when Ray got the error.  Then when I tried to put the item back in edit it mode I received the same stacktrace Ray did.  

The fix was reordering the calls when putting an item in edit mode, which is to check out the master branch, then delete the local scratch pad.  The error was having those reversed.  

Below is what I wrote on the Jira ticket IAT-447.

--- Jira Ticket IAT-447 ---
The issue does not always happen. It happens when there is more than one instance of IMS running, for example during the demo when this issue came up there were two IMS instance. There is a loadbalancer in UAT as well balancing requests between the two instances.
1. The user was working with a specific item, doing things like create and create commit. The user was being load balanced between the two IMS servers, server 1 and server 2. The point being both IMS servers had cloned the item (i.e. a repo) locally.
2. The user discarded their edits which cleaned up the local repo on IMS server 1. Cleaned up in the sense it deleted the scratchpad, and specifically deleted it locally on IMS server 1. This explains why we don't see the issue locally as we are running a single IMS instance.
3. The user then clicked to edit the same item. The theory is this happened on IMS server 2 which had not been cleaned up. The IMS code to edit an item first tries to delete the local scratch pad, checks out master, and then creates a new scratch pad branch.
The problem is in step 3. The IMS code should not first try to delete the local scratch pad. The reason is the local repo has the scratch pad currently checked out. This just happens to be the state of the local repo on this server given how the load balancing works with more than one IMS instance.
The solution is when editing is to first checkout the master branch and then delete the local scratch pad branch.
