### PR TITLE
Feature/iat 320

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,4 +34,4 @@ artifactoryPassword=
 
 # kubernetes
 kubecfgState=s3://kops-sbtds-org-state-store
-kubecfgName=awsdev.sbtds.org
+kubecfgName=iat-dev.sbtds.org

--- a/src/main/java/org/opentestsystem/saaif/item/SaaifItemConstants.java
+++ b/src/main/java/org/opentestsystem/saaif/item/SaaifItemConstants.java
@@ -43,20 +43,23 @@ public interface SaaifItemConstants {
      * The SAAIF item formats.
      */
     interface ItemFormat {
-        String FORMAT_SHORT_ANSWER = "sa";
+        String FORMAT_SA = "sa";
+        String FORMAT_WER = "wer";
     }
 
     /**
      * The SAAIF item page layouts defined for each item format.
      */
     interface ItemPageLayout {
-        String PAGE_LAYOUT_SHORT_ANSWER = "8, 21";
+        String PAGE_LAYOUT_SA = "8, 21";
+        String PAGE_LAYOUT_WER = "21";
     }
 
     /**
      * The SAAIF item response types.
      */
     interface ItemResponseType {
+        String RESPONSE_TYPE_PLAIN_TEXT = "PlainText";
         String RESPONSE_TYPE_HTML_EDITOR = "HTMLEditor";
     }
 

--- a/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
+++ b/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
@@ -108,10 +108,10 @@ public class SaaifItemFactory {
     }
 
     /**
-     * The minimum valid short answer {@link org.opentestsystem.saaif.item.ItemRelease.Item} instance.  A minimum short
-     * answer requires at least one {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content} instance so there
-     * should be at least one language passed in.  For each language given, there will be that number of minimum {@link
-     * org.opentestsystem.saaif.item.ItemRelease.Item.Content} instances associated with the item.
+     * The minimum valid WER (written extended response) {@link org.opentestsystem.saaif.item.ItemRelease.Item}
+     * instance. A minimum WER requires at least one {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content}
+     * instance so there should be at least one language passed in.  For each language given, there will be that number
+     * of minimum {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content} instances associated with the item.
      *
      * @param itemId    The item ID to set.
      * @param languages The languages to create {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content}

--- a/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
+++ b/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
@@ -21,10 +21,13 @@ import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.Ite
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemId;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemPageLayout;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemResponseType;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_WER;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_SA;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_WER;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemResponseType.RESPONSE_TYPE_HTML_EDITOR;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemResponseType.RESPONSE_TYPE_PLAIN_TEXT;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_RELEASE_VERSION;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
 
@@ -72,8 +75,11 @@ public class SaaifItemFactory {
     public ItemRelease.Item newItem(String itemId, String itemFormat, String... languages) {
         final ItemRelease.Item item;
         switch (itemFormat) {
-            case FORMAT_SHORT_ANSWER:
+            case FORMAT_SA:
                 item = newShortAnswerItem(itemId, languages);
+                break;
+            case FORMAT_WER:
+                item = newWerItem(itemId, languages);
                 break;
             default:
                 item = null;
@@ -95,13 +101,38 @@ public class SaaifItemFactory {
      */
     public ItemRelease.Item newShortAnswerItem(String itemId, String... languages) {
         final ItemRelease.Item.Attriblist attributeList = newItemAttributeList(itemId,
-            FORMAT_SHORT_ANSWER, PAGE_LAYOUT_SHORT_ANSWER, RESPONSE_TYPE_HTML_EDITOR);
+            FORMAT_SA, PAGE_LAYOUT_SA, RESPONSE_TYPE_PLAIN_TEXT);
 
+        final ItemRelease.Item item = newDefaultItem(itemId, FORMAT_SA, languages);
+        item.setAttriblist(attributeList);
+        return item;
+    }
+
+    /**
+     * The minimum valid short answer {@link org.opentestsystem.saaif.item.ItemRelease.Item} instance.  A minimum short
+     * answer requires at least one {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content} instance so there
+     * should be at least one language passed in.  For each language given, there will be that number of minimum {@link
+     * org.opentestsystem.saaif.item.ItemRelease.Item.Content} instances associated with the item.
+     *
+     * @param itemId    The item ID to set.
+     * @param languages The languages to create {@link org.opentestsystem.saaif.item.ItemRelease.Item.Content}
+     *                  instances.
+     * @return A {@link org.opentestsystem.saaif.item.ItemRelease.Item} instance.
+     */
+    public ItemRelease.Item newWerItem(String itemId, String... languages) {
+        final ItemRelease.Item.Attriblist attributeList = newItemAttributeList(itemId,
+            FORMAT_WER, PAGE_LAYOUT_WER, RESPONSE_TYPE_HTML_EDITOR);
+
+        final ItemRelease.Item item = newDefaultItem(itemId, FORMAT_WER, languages);
+        item.setAttriblist(attributeList);
+        return item;
+    }
+
+    private ItemRelease.Item newDefaultItem(String itemId, String itemFormat, String... languages) {
         final ItemRelease.Item item = OBJECT_FACTORY.createItemreleaseItem();
         item.setId(itemId);
-        item.setFormat(FORMAT_SHORT_ANSWER);
+        item.setFormat(itemFormat);
         item.setVersion(ITEM_VERSION);
-        item.setAttriblist(attributeList);
 
         if (languages != null) {
             for (String lang : languages) {

--- a/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
+++ b/src/main/java/org/opentestsystem/saaif/item/SaaifItemFactory.java
@@ -32,8 +32,7 @@ import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
 
 /**
- * Creates different entities, setting specific properties depending on what is required, and depending on the
- * scenario.
+ * Creates different entities, setting specific properties depending on what is required.
  */
 public class SaaifItemFactory {
 
@@ -128,7 +127,15 @@ public class SaaifItemFactory {
         return item;
     }
 
-    private ItemRelease.Item newDefaultItem(String itemId, String itemFormat, String... languages) {
+    /**
+     * Creates a minimal item.  The item does not have attributes set so it is not a valid minimal item.
+     *
+     * @param itemId     The item ID to set.
+     * @param itemFormat The format of the item being created.
+     * @param languages  The languages to create on the item.
+     * @return A {@link org.opentestsystem.saaif.item.ItemRelease.Item} instance.
+     */
+    public ItemRelease.Item newDefaultItem(String itemId, String itemFormat, String... languages) {
         final ItemRelease.Item item = OBJECT_FACTORY.createItemreleaseItem();
         item.setId(itemId);
         item.setFormat(itemFormat);

--- a/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/client/GitClientTest.java
@@ -67,7 +67,7 @@ import static org.opentestsystem.ap.ims.client.GitClient.GIT_CONFIG_USER_NAME;
 import static org.opentestsystem.ap.ims.client.GitClient.SCRATCH_PAD;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GitClientTest {
@@ -469,7 +469,7 @@ public class GitClientTest {
 
     @Test
     public void itShouldReadItemFile() {
-        final ItemRelease expected = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease expected = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA);
         gitClient.writeItemFile(expected);
 
         final ItemRelease actual = spyGitClient.readItemFile();

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
@@ -49,7 +49,7 @@ import static org.opentestsystem.ap.ims.util.IMSTestUtil.COMMIT_MESSAGE;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_FACTORY;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -123,11 +123,11 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldUpdateItemWhenScratchPadOwnerIsUserMakingUpdateRequest() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         doNothing().when(spyRepository).beginEditItem(ITEM_BANK_USER, ITEM_ID);
@@ -142,11 +142,11 @@ public class ItemRepositoryTest {
 
     @Test(expected = ValidationException.class)
     public void itShouldThrowWhenUpdatingItemAndScratchPadOwnerIsNull() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         doNothing().when(spyRepository).beginEditItem(ITEM_BANK_USER, ITEM_ID);
@@ -229,11 +229,11 @@ public class ItemRepositoryTest {
 
     @Test(expected = ResourceNotFoundException.class)
     public void itShouldThrowWhenFindingItem() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         // make scrach pad owner the same as the user making request
@@ -248,11 +248,11 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldFindItemAndCheckoutMaster() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         // make scrach pad owner the same as the user making request
@@ -274,11 +274,11 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldFindItemAndSetBeingEditedBy() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         // make scrach pad owner the same as the user making request
@@ -302,11 +302,11 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldFindItemAndSetBeingCreatedBy() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
-        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER,
+        final ItemRelease saaifITem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA,
             LANG_ENU);
 
         // make scrach pad owner the same as the user making request
@@ -330,15 +330,15 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldBeginCreateItem() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
-        final ItemRelease saaifItem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
+        final ItemRelease saaifItem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA);
 
-        when(mockSaaifItemFactory.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU)).thenReturn(saaifItem);
+        when(mockSaaifItemFactory.newAssessmentItem(ITEM_ID, FORMAT_SA, LANG_ENU)).thenReturn(saaifItem);
         when(mockGitClientFactory.openRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
 
         when(mockItemMapper.mapToEntityItem(saaifItem.getItem())).thenReturn(expectedItem);
 
-        final Item actualItem = spyRepository.beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item actualItem = spyRepository.beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SA);
 
         assertThat(actualItem.getBeingCreatedBy()).isEqualTo(ITEM_BANK_USER.getUsername());
         assertThat(actualItem.getBeingEditedBy()).isNull();

--- a/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/rest/v1/ItemApiIT.java
@@ -45,7 +45,7 @@ import static org.opentestsystem.ap.ims.rest.ItemRequestWrapper.ItemRequestWrapp
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.COMMIT_MESSAGE;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -88,14 +88,14 @@ public class ItemApiIT {
 
     @Test
     public void isShouldGetItem() throws Exception {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
 
         given(itemService.findItem(ITEM_ID)).willReturn(expectedItem);
 
         mvc.perform(get(API_BASE_PATH + ITEM_ID).contentType(contentType))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id", is(ITEM_ID)))
-            .andExpect(jsonPath("$.type", is(FORMAT_SHORT_ANSWER)))
+            .andExpect(jsonPath("$.type", is(FORMAT_SA)))
             .andExpect(jsonPath("$.version", is(ITEM_VERSION)))
             .andExpect(jsonPath("$.beingCreatedBy", is(ITEM_BANK_USER.getUsername())));
 
@@ -106,9 +106,9 @@ public class ItemApiIT {
 
     @Test
     public void itShouldCreateNewItem() throws Exception {
-        final Item newItemRequest = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item newItemRequest = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
 
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         given(itemService.createNewItem(newItemRequest)).willReturn(expectedItem);
 
         mvc.perform(post(API_BASE_PATH + "/begin")
@@ -116,7 +116,7 @@ public class ItemApiIT {
             .content(json(newItemRequest)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id", is(ITEM_ID)))
-            .andExpect(jsonPath("$.type", is(FORMAT_SHORT_ANSWER)))
+            .andExpect(jsonPath("$.type", is(FORMAT_SA)))
             .andExpect(jsonPath("$.version", is(ITEM_VERSION)))
             .andExpect(jsonPath("$.beingCreatedBy", is(ITEM_BANK_USER.getUsername())));
 
@@ -125,7 +125,7 @@ public class ItemApiIT {
 
     @Test
     public void itShouldSaveNewItem() throws Exception {
-        final Item itemToUpdate = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item itemToUpdate = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
 
         mvc.perform(post(API_BASE_PATH + ITEM_ID + "/save")
             .contentType(contentType)
@@ -137,7 +137,7 @@ public class ItemApiIT {
 
     @Test
     public void itShouldCommitNewItem() throws Exception {
-        final Item itemToCommit = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item itemToCommit = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
 
         final ItemRequestWrapper itemRequestWrapper = aItemRequestWrapper().message(COMMIT_MESSAGE).item(itemToCommit)
             .build();
@@ -169,7 +169,7 @@ public class ItemApiIT {
 
     @Test
     public void itShouldEdit() throws Exception {
-        final Item itemToUpdate = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item itemToUpdate = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
 
         mvc.perform(put(API_BASE_PATH + ITEM_ID + "/save")
             .contentType(contentType)
@@ -181,7 +181,7 @@ public class ItemApiIT {
 
     @Test
     public void itShouldCommitEdit() throws Exception {
-        final Item itemToCommit = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item itemToCommit = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
 
         final ItemRequestWrapper itemRequestWrapper = aItemRequestWrapper().message(COMMIT_MESSAGE).item(itemToCommit)
             .build();

--- a/src/test/java/org/opentestsystem/ap/ims/service/ItemServiceIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/service/ItemServiceIT.java
@@ -43,7 +43,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static java.lang.System.out;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 
 @Ignore
 @ActiveProfiles(value = "it-test, itembank-on")
@@ -131,7 +131,7 @@ public class ItemServiceIT {
     public void itShouldCreateSAItemAndUpdateItWithChanges() throws JsonProcessingException {
         Item item = null;
 
-        final String itemType = FORMAT_SHORT_ANSWER;
+        final String itemType = FORMAT_SA;
         final Item newItem = step1_CreateNewItem(itemType);
         final String itemId = newItem.getId();
 
@@ -150,7 +150,7 @@ public class ItemServiceIT {
     }
 
     private Item step1_CreateNewItem(String type) {
-        final Item newItem = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
+        final Item newItem = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
         return service.createNewItem(newItem);
     }
 

--- a/src/test/java/org/opentestsystem/ap/ims/service/ItemServiceTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/service/ItemServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_FACTORY;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
 
@@ -79,7 +79,7 @@ public class ItemServiceTest {
 
     @Test(expected = ValidationException.class)
     public void itShouldThrowWhenSavingItemAndItemIdIsNull() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         service.saveItem(null, expectedItem);
     }
 
@@ -90,8 +90,8 @@ public class ItemServiceTest {
 
     @Test
     public void itShouldSaveItem() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
-        final ItemRelease saaifItem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
+        final ItemRelease saaifItem = ITEM_FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA, LANG_ENU);
 
         when(mockItemMapper.mapToSaaifAssesmentItem(expectedItem)).thenReturn(saaifItem);
 
@@ -109,7 +109,7 @@ public class ItemServiceTest {
 
     @Test
     public void itShouldFindItem() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
 
         when(mockRepository.findItem(ITEM_BANK_USER, ITEM_ID)).thenReturn(expectedItem);
 
@@ -173,27 +173,27 @@ public class ItemServiceTest {
 
     @Test
     public void itShouldCreateNewItem() {
-        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final Item expectedItem = testUtil.newItem(ITEM_ID, FORMAT_SA);
         // want to confirm the service sets the correct one
         expectedItem.setBeingCreatedBy(null);
         expectedItem.setBeingEditedBy(null);
 
         when(mockRepository.newItem(ITEM_BANK_USER)).thenReturn(ITEM_ID);
 
-        when(mockRepository.beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SHORT_ANSWER)).thenReturn(expectedItem);
+        when(mockRepository.beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SA)).thenReturn(expectedItem);
 
-        final Item newItemRequest = Item.ItemBuilder.anItem().type(FORMAT_SHORT_ANSWER).build();
-        newItemRequest.setType(FORMAT_SHORT_ANSWER);
+        final Item newItemRequest = Item.ItemBuilder.anItem().type(FORMAT_SA).build();
+        newItemRequest.setType(FORMAT_SA);
 
         final Item actualItem = service.createNewItem(newItemRequest);
 
         assertThat(actualItem.getId()).isEqualTo(ITEM_ID);
-        assertThat(actualItem.getType()).isEqualTo(FORMAT_SHORT_ANSWER);
+        assertThat(actualItem.getType()).isEqualTo(FORMAT_SA);
         assertThat(actualItem.getVersion()).isEqualTo(ITEM_VERSION);
 
         verify(mockSecurityUtil, times(1)).getItemBankUser();
         verify(mockRepository, times(1)).newItem(ITEM_BANK_USER);
-        verify(mockRepository, times(1)).beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SHORT_ANSWER);
+        verify(mockRepository, times(1)).beginCreateItem(ITEM_BANK_USER, ITEM_ID, FORMAT_SA);
     }
 
 }

--- a/src/test/java/org/opentestsystem/ap/ims/util/IMSTestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/IMSTestUtil.java
@@ -37,7 +37,7 @@ import org.opentestsystem.saaif.item.SaaifItemFactory;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemAnswerKey;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ESN;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
@@ -158,7 +158,7 @@ public class IMSTestUtil {
     // ------------------------------------------------------------------------
 
     public Item newItem() {
-        return newItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        return newItem(ITEM_ID, FORMAT_SA);
     }
 
     public Item newItem(String id, String type) {

--- a/src/test/java/org/opentestsystem/ap/ims/util/SaaifAssemblerTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/SaaifAssemblerTest.java
@@ -27,7 +27,7 @@ import org.opentestsystem.saaif.item.SaaifItemFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 
 public class SaaifAssemblerTest {
 
@@ -61,7 +61,7 @@ public class SaaifAssemblerTest {
 
     @Test
     public void itShouldMarshalObjectToXMLAndWriteItToFile() {
-        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA);
         saaifAssembler.writeXmlToFile(shortAnswer, Paths.get(testUtil.getLocalRepoDir().toString(), "item-file.xml"));
         assertThat(Files.exists(itemFilePath)).isEqualTo(true);
     }
@@ -69,13 +69,13 @@ public class SaaifAssemblerTest {
     @Test
     public void itShouldUnmarshalXMLFileToObject() {
         final Path itemXmlFile = Paths.get(testUtil.getLocalRepoDir().toString(), "item-file.xml");
-        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SHORT_ANSWER);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(ITEM_ID, FORMAT_SA);
         saaifAssembler.writeXmlToFile(shortAnswer, itemXmlFile);
 
         final ItemRelease item = saaifAssembler.readXmlFromFile(itemXmlFile);
 
         assertThat(item.getItem().getId()).isEqualTo(ITEM_ID);
-        assertThat(item.getItem().getFormat()).isEqualTo(FORMAT_SHORT_ANSWER);
+        assertThat(item.getItem().getFormat()).isEqualTo(FORMAT_SA);
 
     }
 

--- a/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
+++ b/src/test/java/org/opentestsystem/saaif/item/ItemReleaseTest.java
@@ -25,7 +25,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_RELEASE_VERSION;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
@@ -47,7 +47,7 @@ public class ItemReleaseTest {
     @Test
     public void itShouldCreateAndMarshalMinimumShortAnswerToXml() throws Exception {
         // confirm the factory creates the minimum object as expected
-        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(itemId, FORMAT_SHORT_ANSWER, LANG_ENU);
+        final ItemRelease shortAnswer = FACTORY.newAssessmentItem(itemId, FORMAT_SA, LANG_ENU);
 
         assertThat(shortAnswer).isNotNull();
         assertThat(shortAnswer.getItem()).isNotNull();
@@ -68,7 +68,7 @@ public class ItemReleaseTest {
         xmlMarshaller.marshal(shortAnswer, stream);
 
         String xmlString = new String(os.toByteArray(), StandardCharsets.UTF_8);
-        assertThat(xmlString).contains(String.format("<item format=\"%s\" id=\"%s\" version=\"%s\">", FORMAT_SHORT_ANSWER, itemId, ITEM_VERSION));
+        assertThat(xmlString).contains(String.format("<item format=\"%s\" id=\"%s\" version=\"%s\">", FORMAT_SA, itemId, ITEM_VERSION));
         assertThat(xmlString).contains(String.format("<content language=\"%s\" version=\"%s\">", LANG_ENU, ITEM_RELEASE_VERSION.toString()));
         assertThat(xmlString).contains("<stem><![CDATA[]]></stem>");
     }

--- a/src/test/java/org/opentestsystem/saaif/item/SaaifItemFactoryTest.java
+++ b/src/test/java/org/opentestsystem/saaif/item/SaaifItemFactoryTest.java
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.opentestsystem.saaif.item;
 
 import java.util.Arrays;
@@ -30,12 +29,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemAnswerKey;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemFormat;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemId;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemPageLayout;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemAttribute.ItemResponseType;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_SA;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemFormat.FORMAT_WER;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ENU;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemLanguage.LANG_ESN;
-import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_SHORT_ANSWER;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_SA;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemPageLayout.PAGE_LAYOUT_WER;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemResponseType.RESPONSE_TYPE_HTML_EDITOR;
+import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemResponseType.RESPONSE_TYPE_PLAIN_TEXT;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_RELEASE_VERSION;
 import static org.opentestsystem.saaif.item.SaaifItemConstants.ItemVersion.ITEM_VERSION;
 import static org.opentestsystem.saaif.item.SaaifTestUtil.TEST_ITEM_ID;
@@ -54,22 +60,40 @@ public class SaaifItemFactoryTest {
     }
 
     @Test
-    public void itShouldCreateNewAssessmentItem() {
-        final ItemRelease.Item shortAnswer = saaifItemFactory.newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
-        doReturn(shortAnswer).when(spySaaifItemFactory).newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+    public void itShouldCreatNewDefaultContent() {
+        final ItemRelease.Item.Content content = saaifItemFactory.newDefaultContent();
+        assertThat(content.getLanguage()).isEqualTo(LANG_ENU);
+        assertThat(content.getVersion()).isEqualTo(ITEM_RELEASE_VERSION);
+        assertThat(content.getStem()).isEqualTo(EMPTY);
+    }
 
-        final ItemRelease assessmentItem = spySaaifItemFactory.newAssessmentItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+    @Test
+    public void itShouldCreateNewAssessmentItem() {
+        final ItemRelease.Item shortAnswer = saaifItemFactory.newItem(TEST_ITEM_ID, FORMAT_SA, LANG_ENU);
+        doReturn(shortAnswer).when(spySaaifItemFactory).newItem(TEST_ITEM_ID, FORMAT_SA, LANG_ENU);
+
+        final ItemRelease assessmentItem = spySaaifItemFactory.newAssessmentItem(TEST_ITEM_ID, FORMAT_SA, LANG_ENU);
         assertThat(assessmentItem.getItem()).isEqualTo(shortAnswer);
         assertThat(assessmentItem.getVersion()).isEqualTo(ITEM_RELEASE_VERSION);
     }
 
     @Test
-    public void itShouldCreateNewItemForShortAnswer() {
+    public void itShouldCreateNewItemForWER() {
+        final ItemRelease.Item werItem = saaifItemFactory.newWerItem(TEST_ITEM_ID, LANG_ENU);
+
+        doReturn(werItem).when(spySaaifItemFactory).newWerItem(TEST_ITEM_ID, LANG_ENU);
+
+        final ItemRelease.Item item = spySaaifItemFactory.newItem(TEST_ITEM_ID, FORMAT_WER, LANG_ENU);
+        assertThat(item).isEqualTo(werItem);
+    }
+
+    @Test
+    public void itShouldCreateNewItemForSA() {
         final ItemRelease.Item shortAnswerItem = saaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
 
         doReturn(shortAnswerItem).when(spySaaifItemFactory).newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
 
-        final ItemRelease.Item item = spySaaifItemFactory.newItem(TEST_ITEM_ID, FORMAT_SHORT_ANSWER, LANG_ENU);
+        final ItemRelease.Item item = spySaaifItemFactory.newItem(TEST_ITEM_ID, FORMAT_SA, LANG_ENU);
         assertThat(item).isEqualTo(shortAnswerItem);
     }
 
@@ -81,27 +105,75 @@ public class SaaifItemFactoryTest {
 
     @Test
     public void itShouldCreateShortAnswerItem() {
-        final ItemRelease.Item.Content content = saaifItemFactory.newContent(LANG_ENU);
+        final ItemRelease.Item item = saaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
 
-        final ItemRelease.Item.Attriblist attriblist = saaifItemFactory.newItemAttributeList(TEST_ITEM_ID,
-            FORMAT_SHORT_ANSWER, PAGE_LAYOUT_SHORT_ANSWER, RESPONSE_TYPE_HTML_EDITOR);
+        assertNewItem(item, TEST_ITEM_ID, FORMAT_SA, ITEM_VERSION);
+        assertThat(item.getContent()).hasSize(1);
+        assertThat(item.getAttriblist().getAttrib()).hasSize(5);
+        assertNewItemAttributeList(item.getAttriblist().getAttrib(), TEST_ITEM_ID, FORMAT_SA,
+            PAGE_LAYOUT_SA, RESPONSE_TYPE_PLAIN_TEXT);
 
-        doReturn(attriblist).when(spySaaifItemFactory).newItemAttributeList(TEST_ITEM_ID,
-            FORMAT_SHORT_ANSWER, PAGE_LAYOUT_SHORT_ANSWER, RESPONSE_TYPE_HTML_EDITOR);
-
-        doReturn(content).when(spySaaifItemFactory).newContent(LANG_ENU);
-
-        final ItemRelease.Item shortAnswerItem = spySaaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU);
-
-        assertThat(shortAnswerItem.getId()).isEqualTo(TEST_ITEM_ID);
-        assertThat(shortAnswerItem.getFormat()).isEqualTo(FORMAT_SHORT_ANSWER);
-        assertThat(shortAnswerItem.getVersion()).isEqualTo(ITEM_VERSION);
-        assertThat(shortAnswerItem.getAttriblist()).isEqualTo(attriblist);
-        assertThat(shortAnswerItem.getContent()).hasSize(1);
-        assertThat(shortAnswerItem.getContent().get(0)).isEqualTo(content);
-
-        final ItemRelease.Item shortAnswerItem2 = spySaaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU, LANG_ESN);
+        final ItemRelease.Item shortAnswerItem2 = saaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU, LANG_ESN);
         assertThat(shortAnswerItem2.getContent()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldCreateWerItem() {
+        final ItemRelease.Item item = saaifItemFactory.newWerItem(TEST_ITEM_ID, LANG_ENU);
+
+        assertNewItem(item, TEST_ITEM_ID, FORMAT_WER, ITEM_VERSION);
+        assertThat(item.getContent()).hasSize(1);
+        assertThat(item.getAttriblist().getAttrib()).hasSize(5);
+        assertNewItemAttributeList(item.getAttriblist().getAttrib(), TEST_ITEM_ID, FORMAT_WER, PAGE_LAYOUT_WER,
+            RESPONSE_TYPE_HTML_EDITOR);
+
+        final ItemRelease.Item shortAnswerItem2 = saaifItemFactory.newShortAnswerItem(TEST_ITEM_ID, LANG_ENU, LANG_ESN);
+        assertThat(shortAnswerItem2.getContent()).hasSize(2);
+    }
+
+    private void assertNewItem(final ItemRelease.Item item,
+                               final String itemId,
+                               final String itemFormat,
+                               final String itemVersion) {
+        assertThat(item.getId()).isEqualTo(itemId);
+        assertThat(item.getFormat()).isEqualTo(itemFormat);
+        assertThat(item.getVersion()).isEqualTo(itemVersion);
+    }
+
+    private void assertNewItemAttributeList(final List<ItemRelease.Item.Attriblist.Attrib> attribList,
+                                            final String itemId,
+                                            final String itemFormat,
+                                            final String pageLayout,
+                                            final String responseType) {
+
+        final ItemRelease.Item.Attriblist.Attrib itemIdAttr = attribList.stream().filter(attrib -> ItemId.getAttId()
+            .equals(attrib.getAttid())).collect(Collectors.toList()
+        ).get(0);
+
+        final ItemRelease.Item.Attriblist.Attrib itemAnswerKeyAttr = attribList.stream().filter(attrib -> ItemAnswerKey
+            .getAttId().equals(attrib.getAttid())).collect(Collectors
+            .toList()).get(0);
+
+        final ItemRelease.Item.Attriblist.Attrib itemFormatAttr = attribList.stream().filter(attrib -> ItemFormat
+            .getAttId()
+            .equals(attrib.getAttid())).collect(Collectors
+            .toList()).get(0);
+
+        final ItemRelease.Item.Attriblist.Attrib itemPageLayoutAttr = attribList.stream().filter(attrib ->
+            ItemPageLayout
+                .getAttId().equals(attrib.getAttid())).collect(Collectors
+            .toList()).get(0);
+
+        final ItemRelease.Item.Attriblist.Attrib itemResponseTypeAttr = attribList.stream().filter(attrib ->
+            ItemResponseType
+                .getAttId().equals(attrib.getAttid())).collect
+            (Collectors.toList()).get(0);
+
+        assertThat(itemIdAttr.getVal()).isEqualTo(itemId);
+        assertThat(itemAnswerKeyAttr.getVal()).isEqualTo(itemFormat.toUpperCase());
+        assertThat(itemFormatAttr.getVal()).isEqualTo(itemFormat.toUpperCase());
+        assertThat(itemPageLayoutAttr.getVal()).isEqualTo(pageLayout);
+        assertThat(itemResponseTypeAttr.getVal()).isEqualTo(responseType);
     }
 
     @Test
@@ -116,7 +188,8 @@ public class SaaifItemFactoryTest {
     public void itShouldCreateNewItemAttributeList() {
         final List<String> values = Lists.newArrayList("itemId", "SA", "8", "PlainText");
 
-        final ItemRelease.Item.Attriblist attriblist = saaifItemFactory.newItemAttributeList("itemId", "sa", "8", "PlainText");
+        final ItemRelease.Item.Attriblist attriblist = saaifItemFactory.newItemAttributeList("itemId", "sa", "8",
+            "PlainText");
         assertThat(attriblist).isNotNull();
 
         final List<ItemRelease.Item.Attriblist.Attrib> attribs = attriblist.getAttrib();
@@ -127,7 +200,7 @@ public class SaaifItemFactoryTest {
         final List<String> attNames = Arrays.stream(SaaifItemConstants.ItemAttribute.values()).map(SaaifItemConstants
             .ItemAttribute::getName).collect(Collectors.toList());
 
-        for (ItemRelease.Item.Attriblist.Attrib attrib: attribs) {
+        for (ItemRelease.Item.Attriblist.Attrib attrib : attribs) {
             assertThat(attrib.getAttid()).isIn(attIds);
             assertThat(attrib.getName()).isIn(attNames);
             assertThat(attrib.getVal()).isIn(values);


### PR DESCRIPTION
@rmitchell3 

The main change was creating a mapping in the SaaifFactory for creating a new WER item.  The only difference per the spec between them is the attribute list.  Nothing else really had to change.  SA and WER are identical in all other respects.  They take exemplar responses and a stem.  IMS already supports rich text in the sense it puts those values in CDATA[[]] tags.

I corrected the response type attribute value for SA as it was incorrectly HTMLEditor when it should have been PlainText.  

I renamed an constant from FORMAT_SHORT_ANSWER to FORMAT_SA.  That caused a couple more files to get changed.

I also snuck in a kubernetes adjustment.  This is the same as what I did on IAT where the default cluster during a release is the new dev environment I created for us last night.

