### PR TITLE
Feature/iat 467

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -34,5 +34,6 @@ itembank:
   group: "${GITLAB_GROUP:iat-development}"
   localBaseDir: "${GITLAB_LOCAL_BASE_DIR:${HOME}/ItemBank}"
   apiVersion: "${GITLAB_API_VERSION:/api/v4}"
+  bankKey: "${GITLAB_BANK_KEY:187}"
 
 

--- a/src/main/java/org/opentestsystem/ap/ims/config/ItemBankProperties.java
+++ b/src/main/java/org/opentestsystem/ap/ims/config/ItemBankProperties.java
@@ -49,5 +49,7 @@ public class ItemBankProperties {
 
     private String apiVersion;
 
+    private String bankKey;
+
 
 }

--- a/src/main/java/org/opentestsystem/ap/ims/model/Item.java
+++ b/src/main/java/org/opentestsystem/ap/ims/model/Item.java
@@ -43,7 +43,7 @@ public abstract class Item {
 
     public abstract String getType();
 
-    public abstract ItemRelease toSaaif();
+    public abstract ItemRelease toSaaif(final String bankKey);
 
     /**
      * Creates a new saaif item using saaif item passed in as the base.  The model properties are copied

--- a/src/main/java/org/opentestsystem/ap/ims/model/SaItem.java
+++ b/src/main/java/org/opentestsystem/ap/ims/model/SaItem.java
@@ -39,7 +39,7 @@ import static org.opentestsystem.ap.ims.model.ItemMapper.newSaaifItemAttributeLi
 @EqualsAndHashCode(callSuper = true)
 public class SaItem extends Item {
 
-    public static String PAGE_LAYOUT = "8, 21";
+    public static String PAGE_LAYOUT = "21";
 
     public static String RESPONSE_TYPE = "PlainText";
 

--- a/src/main/java/org/opentestsystem/ap/ims/model/SaItem.java
+++ b/src/main/java/org/opentestsystem/ap/ims/model/SaItem.java
@@ -55,12 +55,13 @@ public class SaItem extends Item {
     // ------------------------------------------------------------------------
 
     @Override
-    public ItemRelease toSaaif() {
+    public ItemRelease toSaaif(final String bankKey) {
         final ItemRelease.Item.Attriblist attributeList = newSaaifItemAttributeList(getId(), getType(), PAGE_LAYOUT, RESPONSE_TYPE);
 
         final ItemRelease.Item.Content content = newSaaifContent(LANG_ENU);
 
         final ItemRelease.Item item = newSaaifItem(getId(), getType());
+        item.setBankkey(bankKey);
         item.setAttriblist(attributeList);
         item.getContent().add(content);
 

--- a/src/main/java/org/opentestsystem/ap/ims/model/WerItem.java
+++ b/src/main/java/org/opentestsystem/ap/ims/model/WerItem.java
@@ -55,13 +55,14 @@ public class WerItem extends Item {
     // ------------------------------------------------------------------------
 
     @Override
-    public ItemRelease toSaaif() {
+    public ItemRelease toSaaif(final String bankKey) {
         final ItemRelease.Item.Attriblist attributeList = newSaaifItemAttributeList(getId(),
             getType(), PAGE_LAYOUT, RESPONSE_TYPE);
 
         final ItemRelease.Item.Content content = newSaaifContent(LANG_ENU);
 
         final ItemRelease.Item item = newSaaifItem(getId(), getType());
+        item.setBankkey(bankKey);
         item.setAttriblist(attributeList);
         item.getContent().add(content);
 

--- a/src/main/java/org/opentestsystem/ap/ims/repository/ItemRepository.java
+++ b/src/main/java/org/opentestsystem/ap/ims/repository/ItemRepository.java
@@ -262,7 +262,7 @@ public class ItemRepository {
 
         final Item item = itemFactory.newItem(itemId, itemType);
 
-        final ItemRelease saaifItem = item.toSaaif();
+        final ItemRelease saaifItem = item.toSaaif(itemBankProperties.getBankKey());
 
         gitlabClient.claimItem(user, item.getId());
 

--- a/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/repository/ItemRepositoryTest.java
@@ -31,6 +31,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.ims.client.GitClient;
 import org.opentestsystem.ap.ims.client.GitClientFactory;
 import org.opentestsystem.ap.ims.client.GitlabClient;
+import org.opentestsystem.ap.ims.config.ItemBankProperties;
 import org.opentestsystem.ap.ims.model.Item;
 import org.opentestsystem.ap.ims.model.ItemFactory;
 import org.opentestsystem.ap.ims.model.ItemHistory;
@@ -50,7 +51,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.ap.ims.model.ItemConstants.ItemType.TYPE_SA;
+import static org.opentestsystem.ap.ims.util.IMSTestUtil.API_VERSION;
+import static org.opentestsystem.ap.ims.util.IMSTestUtil.BANK_KEY;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.COMMIT_MESSAGE;
+import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_HOST;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_BANK_USER;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
 
@@ -58,6 +62,10 @@ import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
 public class ItemRepositoryTest {
 
     private final IMSTestUtil testUtil = new IMSTestUtil();
+
+    @Mock
+    private ItemBankProperties mockItemBankProperties;
+
 
     @Mock
     private ItemIdGenerator mockItemIdGenerator;
@@ -77,7 +85,6 @@ public class ItemRepositoryTest {
     @Mock
     private ItemFactory mockItemFactory;
 
-
     @Mock
     Item mockItem = mock(Item.class);
 
@@ -87,10 +94,16 @@ public class ItemRepositoryTest {
 
     @Before
     public void setup() throws IOException {
+
+        when(mockItemBankProperties.getBankKey()).thenReturn(BANK_KEY);
+        when(mockItemBankProperties.getHost()).thenReturn(ITEM_BANK_HOST);
+        when(mockItemBankProperties.getApiVersion()).thenReturn(API_VERSION);
+
         when(mockItemRepositoryFactory.getGitClientFactory()).thenReturn(mockGitClientFactory);
         when(mockItemRepositoryFactory.getGitlabClient()).thenReturn(mockGitlabClient);
         when(mockItemRepositoryFactory.getItemFactory()).thenReturn(mockItemFactory);
         when(mockItemRepositoryFactory.getItemIdGenerator()).thenReturn(mockItemIdGenerator);
+        when(mockItemRepositoryFactory.getItemBankProperties()).thenReturn(mockItemBankProperties);
 
         when(mockItemIdGenerator.generateItemId()).thenReturn(ITEM_ID);
 
@@ -152,7 +165,7 @@ public class ItemRepositoryTest {
 
     @Test
     public void itShouldUpdateItemWhenScratchPadOwnerIsUserMakingUpdateRequest() {
-        final ItemRelease saaifItem = testUtil.newSaItem().toSaaif();
+        final ItemRelease saaifItem = testUtil.newSaItem().toSaaif(BANK_KEY);
 
         when(mockItem.toSaaif(saaifItem)).thenReturn(saaifItem);
         when(mockGitClient.findScratchPadOwner()).thenReturn(ITEM_BANK_USER.getUsername());
@@ -355,7 +368,7 @@ public class ItemRepositoryTest {
 
         when(mockItemFactory.newItem(ITEM_ID, TYPE_SA)).thenReturn(mockItem);
         when(mockGitClientFactory.openRepository(ITEM_BANK_USER, ITEM_ID)).thenReturn(mockGitClient);
-        when(mockItem.toSaaif()).thenReturn(saaifItem);
+        when(mockItem.toSaaif(BANK_KEY)).thenReturn(saaifItem);
 
         final Item actualItem = spyRepository.beginCreateItem(ITEM_BANK_USER, ITEM_ID, TYPE_SA);
         assertThat(actualItem).isEqualTo(mockItem);

--- a/src/test/java/org/opentestsystem/ap/ims/util/IMSTestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/IMSTestUtil.java
@@ -57,6 +57,11 @@ public class IMSTestUtil {
 
     public static final String ITEM_ID = "testItemId";
 
+    public static final String ITEM_BANK_HOST = "http://itembank.com";
+    public static final String API_VERSION = "/api/version";
+
+    public static final String BANK_KEY = "187";
+
     public static final String COMMIT_MESSAGE = "this is a commit message";
 
     public static final String PROMPT = "This is a prompt";
@@ -177,11 +182,11 @@ public class IMSTestUtil {
 
     public ItemRelease newSaaifSaItem() {
         final SaItem item = newSaItem();
-        return item.toSaaif();
+        return item.toSaaif(BANK_KEY);
     }
 
     public ItemRelease newSaaifWerItem() {
         final WerItem item = newWerItem();
-        return item.toSaaif();
+        return item.toSaaif(BANK_KEY);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/ims/util/SaaifAssemblerTest.java
+++ b/src/test/java/org/opentestsystem/ap/ims/util/SaaifAssemblerTest.java
@@ -28,6 +28,7 @@ import org.opentestsystem.saaif.item.ItemRelease;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.ap.ims.model.ItemConstants.ItemType.TYPE_SA;
+import static org.opentestsystem.ap.ims.util.IMSTestUtil.BANK_KEY;
 import static org.opentestsystem.ap.ims.util.IMSTestUtil.ITEM_ID;
 
 public class SaaifAssemblerTest {
@@ -80,7 +81,7 @@ public class SaaifAssemblerTest {
 
     private ItemRelease newSaaifItem() {
         final Item item = FACTORY.newItem(ITEM_ID, TYPE_SA);
-        final ItemRelease saaifItem = item.toSaaif();
+        final ItemRelease saaifItem = item.toSaaif(BANK_KEY);
         return saaifItem;
     }
 }


### PR DESCRIPTION
The bank key is configurable.  It is similar in concept to the item group.  An instance of IMS is configured with a bank key. 

Bank key doesn't change for that instance.  A different instance of IMS can be configured with a different bank key.  There is no way to use more than one bank key for an IMS instance.  

The default bank key is 187.