### PR TITLE
IAT-492:  The main/resources/logback.xml is set to use INFO by defaul…

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -37,3 +37,9 @@ itembank:
   bankKey: "${GITLAB_BANK_KEY:187}"
 
 
+logging:
+  level:
+    org:
+      opentestsystem:
+        ap:
+          ims: DEBUG


### PR DESCRIPTION
Added to the root application.yml file a setting so the ids classes log at level DEBUG.  This is for local development only.  By default all other environments are set to INFO unless overriden by the configuration service.