### PR TITLE
Feature/iat 363

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -27,8 +27,8 @@ spring:
     enabled: "${SESSION_CLUSTER_ENABLED:true}"
   datasource:
     url: "${DB_URL:jdbc:mysql://localhost:3306/iat?useSSL=false}"
-    username: "${DB_USER:iat}"
-    password: "${DB_PASSWORD:Password}"
+    username: "${DB_USER}"
+    password: "${DB_PASSWORD}"
 
 itembank:
   host: "${GITLAB_HOST:https://gitlab-dev.smarterbalanced.org}"
@@ -46,3 +46,9 @@ logging:
       opentestsystem:
         ap:
           ims: DEBUG
+
+---
+spring:
+  profiles: dev
+  datasource:
+    url: "jdbc:mysql://iat-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:3306/iat"

--- a/application.yml
+++ b/application.yml
@@ -26,7 +26,7 @@ spring:
   session:
     enabled: "${SESSION_CLUSTER_ENABLED:true}"
   datasource:
-    url: "${DB_URL:jdbc:mysql://localhost:3306/iat?useSSL=false}"
+    url: "${DB_URL:jdbc:mysql://iat-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:3306/iat?useSSL=false}"
     username: "${DB_USER}"
     password: "${DB_PASSWORD}"
 
@@ -49,6 +49,6 @@ logging:
 
 ---
 spring:
-  profiles: dev
+  profiles: local
   datasource:
-    url: "jdbc:mysql://iat-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:3306/iat"
+    url: "jdbc:mysql://localhost:3306/iat?useSSL=false"

--- a/application.yml
+++ b/application.yml
@@ -25,6 +25,10 @@ security:
 spring:
   session:
     enabled: "${SESSION_CLUSTER_ENABLED:true}"
+  datasource:
+    url: "${DB_URL:jdbc:mysql://localhost:3306/iat?useSSL=false}"
+    username: "${DB_USER:iat}"
+    password: "${DB_PASSWORD:Password}"
 
 itembank:
   host: "${GITLAB_HOST:https://gitlab-dev.smarterbalanced.org}"
@@ -35,7 +39,6 @@ itembank:
   localBaseDir: "${GITLAB_LOCAL_BASE_DIR:${HOME}/ItemBank}"
   apiVersion: "${GITLAB_API_VERSION:/api/v4}"
   bankKey: "${GITLAB_BANK_KEY:187}"
-
 
 logging:
   level:

--- a/application.yml
+++ b/application.yml
@@ -26,7 +26,7 @@ spring:
   session:
     enabled: "${SESSION_CLUSTER_ENABLED:true}"
   datasource:
-    url: "${DB_URL:jdbc:mysql://iat-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:3306/iat?useSSL=false}"
+    url: "${DB_URL:jdbc:mysql://iat-dev-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:3306/iat?useSSL=false}"
     username: "${DB_USER}"
     password: "${DB_PASSWORD}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-data-redis'
+    compile 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     compile 'org.springframework.cloud:spring-cloud-starter-config'
 
@@ -81,6 +82,8 @@ dependencies {
     compile 'io.springfox:springfox-swagger2:2.6.1'
     compile 'io.springfox:springfox-swagger-ui:2.6.1'
 
+    compile 'mysql:mysql-connector-java'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtime 'org.springframework.boot:spring-boot-devtools'
@@ -88,6 +91,8 @@ dependencies {
     testCompile 'org.springframework.boot:spring-boot-starter-test'
 
     testCompile 'org.projectlombok:lombok'
+
+    testCompile 'org.hsqldb:hsqldb'
 }
 
 dependencyManagement {

--- a/db/createdb
+++ b/db/createdb
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+EXPECTED_ARGS=3
+E_BADARGS=65
+MYSQL=`which mysql`
+
+Q1="CREATE DATABASE IF NOT EXISTS $1;"
+Q2="GRANT USAGE ON *.* TO $2@localhost IDENTIFIED BY '$3';"
+Q3="GRANT ALL PRIVILEGES ON $1.* TO $2@localhost;"
+Q4="FLUSH PRIVILEGES;"
+SQL="${Q1}${Q2}${Q3}${Q4}"
+
+if [ $# -ne $EXPECTED_ARGS ]
+then
+  echo "Usage: $0 dbname dbuser dbpass"
+  exit $E_BADARGS
+fi
+
+$MYSQL -uroot -p -e "$SQL"

--- a/db/createdb
+++ b/db/createdb
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Creates a new database on the localhost instance of MySQL.  The
+# new database is named 'iat'.  A user is created for the new database
+# with the username 'iat'.  Running the script requires an argument
+# which is the password for the new user.
+#
 
 EXPECTED_ARGS=1
 E_BADARGS=65
@@ -12,8 +18,8 @@ SQL="${Q1}${Q2}${Q3}${Q4}"
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
-  echo "Script creates database 'iat' for user 'iat'.  You must provide password for user 'iat'."
-  echo "Usage: $0 {iat-user-password}"
+  echo "Creating database 'iat' for user 'iat' failed.  You must provide password for user."
+  echo "Usage: $0 {password}"
   exit $E_BADARGS
 fi
 

--- a/db/createdb
+++ b/db/createdb
@@ -1,18 +1,19 @@
 #!/bin/bash
 
-EXPECTED_ARGS=3
+EXPECTED_ARGS=1
 E_BADARGS=65
 MYSQL=`which mysql`
 
-Q1="CREATE DATABASE IF NOT EXISTS $1;"
-Q2="GRANT USAGE ON *.* TO $2@localhost IDENTIFIED BY '$3';"
-Q3="GRANT ALL PRIVILEGES ON $1.* TO $2@localhost;"
+Q1="CREATE DATABASE IF NOT EXISTS iat;"
+Q2="GRANT USAGE ON *.* TO iat@localhost IDENTIFIED BY '$1';"
+Q3="GRANT ALL PRIVILEGES ON iat.* TO iat@localhost;"
 Q4="FLUSH PRIVILEGES;"
 SQL="${Q1}${Q2}${Q3}${Q4}"
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
-  echo "Usage: $0 dbname dbuser dbpass"
+  echo "Script creates database 'iat' for user 'iat'.  You must provide password for user 'iat'."
+  echo "Usage: $0 {iat-user-password}"
   exit $E_BADARGS
 fi
 

--- a/src/test/java/org/opentestsystem/ap/ims/IMSApplicationIT.java
+++ b/src/test/java/org/opentestsystem/ap/ims/IMSApplicationIT.java
@@ -31,6 +31,4 @@ public class IMSApplicationIT {
 	public void itShouldLoadApplication() {
 
 	}
-
-
 }

--- a/src/test/resources/application-it-test.yml
+++ b/src/test/resources/application-it-test.yml
@@ -9,6 +9,8 @@ security:
 spring:
   session:
     enabled: "false"
+  jpa:
+    database: hsql
 
 itembank:
   test:


### PR DESCRIPTION
https://confluence.fairwaytech.com/display/IAT/MySQL

IMS starts locally pointing to the AWS MySQL DEV DB.  This requires us to have a couple env vars added to our computer.  I'll slack those so Tess is included.

I tested docker compose from IMS.  It works as expected.  IAT docker compose should as well but I'll test.  It should because everything is served up by the config service.  Make sure to pull down the latest config repo so you have the latest.  You'll see the datasource configuration in there.