### PR TITLE
IAT-603:  Add the BOM character \ufeff to the start of the CSV output…

### DIFF
--- a/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
+++ b/src/main/java/org/opentestsystem/ap/ims/rest/v1/ItemApi.java
@@ -100,9 +100,11 @@ public class ItemApi {
 
         try (final InputStream csvStream = IOUtils.toInputStream(csvString, "UTF-8")) {
             response.addHeader("Content-disposition", "attachment;filename=item-" + itemId + "-history.csv");
-            response.setContentType("text/csv");
+            response.setContentType("text/csv; charset=UTF-8");
             response.setCharacterEncoding("UTF-8");
 
+            // prepend BOM
+            IOUtils.write("\ufeff", response.getOutputStream(), "UTF-8");
             IOUtils.copy(csvStream, response.getOutputStream());
             response.flushBuffer();
         } catch (IOException e) {


### PR DESCRIPTION
… stream.  Adding this character to the beginning of the stream fixed the issue where the CSV was opening with garbled UTF-8 characters.